### PR TITLE
feat(ui): add theme studio presets, KPI strip, focus layout and docs

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -4,10 +4,30 @@ set -euo pipefail
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 cd "$ROOT_DIR"
 
+# Keep bytecode cache in a writable temp dir to avoid sandbox/macOS cache permission errors.
+if [[ -z "${PYTHONPYCACHEPREFIX:-}" ]]; then
+  export PYTHONPYCACHEPREFIX="${TMPDIR:-/tmp}/sql2bi-pycache"
+fi
+mkdir -p "$PYTHONPYCACHEPREFIX" 2>/dev/null || true
+
 # Prevent committing unresolved merge markers.
-if rg -n "^(<<<<<<<|=======|>>>>>>>)" --glob '!*.lock' >/dev/null 2>&1; then
-  echo "[pre-commit] Found unresolved merge conflict markers." >&2
-  exit 1
+merge_marker_re='^(<<<<<<< .+|=======|>>>>>>> .+)$'
+if command -v rg >/dev/null 2>&1; then
+  if rg -n "$merge_marker_re" --glob '!*.lock' >/dev/null 2>&1; then
+    echo "[pre-commit] Found unresolved merge conflict markers." >&2
+    exit 1
+  fi
+else
+  if grep -RInE "$merge_marker_re" \
+    --exclude='*.lock' \
+    --exclude-dir='.git' \
+    --exclude-dir='node_modules' \
+    --exclude-dir='.venv' \
+    --exclude-dir='__pycache__' \
+    . >/dev/null 2>&1; then
+    echo "[pre-commit] Found unresolved merge conflict markers." >&2
+    exit 1
+  fi
 fi
 
 # Validate shell script syntax.

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -4,6 +4,12 @@ set -euo pipefail
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 cd "$ROOT_DIR"
 
+# Keep bytecode cache in a writable temp dir to avoid sandbox/macOS cache permission errors.
+if [[ -z "${PYTHONPYCACHEPREFIX:-}" ]]; then
+  export PYTHONPYCACHEPREFIX="${TMPDIR:-/tmp}/sql2bi-pycache"
+fi
+mkdir -p "$PYTHONPYCACHEPREFIX" 2>/dev/null || true
+
 "$ROOT_DIR/.githooks/pre-commit"
 
 if ! command -v python3 >/dev/null 2>&1; then
@@ -41,5 +47,9 @@ for f in query_catalog.json semantic_catalog.json chart_plan.json dashboard.json
     exit 1
   fi
 done
+
+if [[ -d "$ROOT_DIR/tests" ]]; then
+  python3 -m unittest discover -s "$ROOT_DIR/tests" -p 'test_*.py'
+fi
 
 echo "[pre-push] checks passed"

--- a/PROMPT-TEMPLATE.zh-CN.md
+++ b/PROMPT-TEMPLATE.zh-CN.md
@@ -1,0 +1,143 @@
+# SQL2BI 规范化 Prompt 模板
+
+这份模板用于让团队成员稳定地产出“可运行的 BI”，避免口头描述过于模糊。
+
+## 1. 使用说明
+
+1. 复制下面的“主模板 Prompt”。
+2. 按字段填空（尤其是数据表结构和业务口径）。
+3. 直接发给支持该项目技能的 AI 助手执行。
+
+## 2. 主模板 Prompt（推荐）
+
+```text
+你现在是 SQL2BI 的 BI 构建助手。请基于我提供的信息，生成可直接在 sql2bi 项目中运行的 BI 方案。
+
+【目标】
+把业务问题转为可执行的 sql.md，并确保可导入 sql2bi 后端生成 dashboard。
+
+【我的输入】
+1) 业务目标：
+{{business_goal}}
+
+2) 核心指标（名称 + 计算口径）：
+{{metrics_definition}}
+
+3) 分析范围（时间、区域、渠道、人群）：
+{{scope}}
+
+4) 可用数据表与字段（必须给出）：
+{{schema_details}}
+
+5) 希望展示的图表/看板偏好（可选）：
+{{chart_preferences}}
+
+6) 过滤器偏好（可选）：
+{{filter_preferences}}
+
+【强约束】
+1. 输出必须包含一个完整 `sql.md`，每个卡片一个 SQL fenced block。
+2. 每个 SQL block 前必须有元数据：
+   - id
+   - datasource
+   - refresh
+   - chart（auto/line/bar/grouped_bar/kpi/table）
+   - filters（逗号分隔）
+3. SQL 禁止 `SELECT *`，关键字段必须显式 `AS` 别名。
+4. 如涉及时间分析，必须给出清晰时间字段与时间过滤条件。
+5. 信息缺失时先列出“默认假设”，不要编造不存在的表字段。
+
+【输出格式（严格按顺序）】
+1) assumptions：列出你使用的默认假设
+2) sql_md：输出完整 sql.md 内容（可直接保存）
+3) run_commands：给出导入与运行命令
+4) validation_checklist：给出 5 条校验项（口径、粒度、过滤器、图表匹配、可解释性）
+
+【运行命令格式要求】
+命令默认基于仓库根目录执行，使用：
+- bash services/start_backend.sh
+- bash services/start_frontend.sh
+- curl POST /api/v1/import/sql-md 导入 sql.md 绝对路径
+
+现在开始生成。
+```
+
+## 3. 场景模板 A：我已经有 SQL
+
+适用：你已经写好 SQL，只想快速变成 BI。
+
+```text
+请使用 SQL2BI 的 sql-to-bi-builder 方式，把下面 SQL 集合整理成可执行 sql.md，并给出运行命令。
+
+要求：
+1) 每条 SQL 生成一个卡片，补齐元数据（id/datasource/refresh/chart/filters）
+2) 图表类型优先按 SQL 语义选择（时间序列=line，单指标聚合=kpi，维度聚合=bar/grouped_bar）
+3) 输出严格包含：assumptions、sql_md、run_commands、validation_checklist
+
+SQL 如下：
+{{your_sql_blocks}}
+```
+
+## 4. 场景模板 B：我只有业务需求
+
+适用：你还没有 SQL，需要助手先设计 SQL 再生成 BI。
+
+```text
+请基于以下业务需求，先设计分析卡片，再生成可执行 sql.md：
+
+业务需求：
+{{business_need}}
+
+数据表结构：
+{{schema_details}}
+
+指标口径：
+{{metrics_definition}}
+
+要求：
+1) 至少输出 4 个卡片（趋势、结构、效率、明细）
+2) 每个卡片给出 SQL，禁止 SELECT *
+3) 每个 SQL block 附元数据（id/datasource/refresh/chart/filters）
+4) 输出严格包含：assumptions、sql_md、run_commands、validation_checklist
+```
+
+## 5. 建议的填空规范（避免歧义）
+
+- `business_goal`：写“决策问题”，不要写“做个看板看看”。
+- `metrics_definition`：写公式，例如 `GMV = sum(paid_amount)`。
+- `scope`：明确日期范围与粒度，例如“2026-01-01~2026-03-31，按日”。
+- `schema_details`：至少包含表名、关键字段、时间字段、关联键。
+- `chart_preferences`：可写“趋势用 line，占比用 grouped_bar，总览用 kpi”。
+- `filter_preferences`：例如“region, channel, biz_date”。
+
+## 6. 最小示例（可直接复制）
+
+```text
+你现在是 SQL2BI 的 BI 构建助手。请基于我提供的信息，生成可直接在 sql2bi 项目中运行的 BI 方案。
+
+【我的输入】
+1) 业务目标：
+判断华东区 2026Q1 销售下滑主要来自流量、转化率还是客单价。
+
+2) 核心指标：
+GMV=sum(pay_amount), CVR=paid_orders/visit_uv, AOV=GMV/paid_orders
+
+3) 分析范围：
+2026-01-01 到 2026-03-31，按 day，region=华东
+
+4) 可用数据表与字段：
+fact_orders(order_id, user_id, pay_time, pay_amount, region, channel, pay_status)
+fact_traffic(dt, region, channel, visit_uv)
+
+5) 图表偏好：
+趋势=line，结构=grouped_bar，总览=kpi
+
+6) 过滤器偏好：
+region, channel, dt
+
+请按以下顺序输出：
+1) assumptions
+2) sql_md
+3) run_commands
+4) validation_checklist
+```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # SQL2BI Workspace
 
+中文使用文档（聚焦两个 skills 的实操）：
+- [USAGE.zh-CN.md](./USAGE.zh-CN.md)
+- [PROMPT-TEMPLATE.zh-CN.md](./PROMPT-TEMPLATE.zh-CN.md)
+
 Turn `sql.md` (multiple SQL blocks in markdown) into a runnable BI prototype:
 - SQL parsing
 - semantic inference
@@ -15,7 +19,7 @@ Turn `sql.md` (multiple SQL blocks in markdown) into a runnable BI prototype:
   - full mode: FastAPI + DuckDB + Polars + Pandas (`services/backend/app.py`)
   - lite mode: stdlib HTTP fallback (`services/backend/app_lite.py`)
 - Frontend service:
-  - full mode: React + Vite + ECharts (`services/frontend`)
+  - full mode: React + Vite + ECharts + Theme Studio (`services/frontend`)
   - lite mode: static HTML/JS + ECharts CDN (`services/frontend-lite`)
 - Test fixtures:
   - SQL markdown: `testdata/sql/demo.sql.md`

--- a/README.md
+++ b/README.md
@@ -59,10 +59,15 @@ Default ports:
 Start:
 
 ```bash
+# terminal A
 bash services/start_backend.sh
+
+# terminal B
 bash services/start_frontend.sh
 bash services/start_skill_agent.sh
 ```
+
+If frontend starts before backend, the UI now shows a clear backend-not-reachable hint (instead of only `Load failed`).
 
 Behavior:
 - If backend Python deps are installed, backend runs in full mode.
@@ -85,7 +90,7 @@ Generated files:
 - `query_catalog.json`
 - `semantic_catalog.json` (includes `dsl_filters`)
 - `chart_plan.json`
-- `dashboard.json` (includes page-level `global_filters`)
+- `dashboard.json` (includes page-level `global_filters`, plus default `ui` unless `--without-ui-theme` is used)
 - `ui/` static scaffold
 - `services/` generated service bundle
 
@@ -111,9 +116,10 @@ Query data API now executes stored SQL against configured datasource (read-only 
 Example import:
 
 ```bash
+# Use an absolute path; replace <repo_root> with your local clone path.
 curl -X POST http://127.0.0.1:18000/api/v1/import/sql-md \
   -H 'Content-Type: application/json' \
-  -d '{"sql_md_path":"/Users/lyg/software/sql2bi/testdata/sql/demo.sql.md"}'
+  -d '{"sql_md_path":"<repo_root>/testdata/sql/demo.sql.md"}'
 ```
 
 ## Integration Tests
@@ -176,6 +182,19 @@ bash scripts/install-git-hooks.sh
 Hooks:
 - `pre-commit`: conflict markers, shell/python syntax, requirement pin checks
 - `pre-push`: smoke pipeline run on `sample.sql.md`
+
+## Unit Tests (minimal)
+
+Run script-level unit tests:
+
+```bash
+python3 -m unittest discover -s tests -p 'test_*.py'
+```
+
+Current coverage focus:
+- `skills/sql-to-bi-builder/scripts/build_dashboard_spec.py`
+  - helper behavior (`unique_keep_order`, `next_position`)
+  - CLI toggle behavior (`--with-ui-theme` / `--without-ui-theme`)
 
 ## Project Intro Website (Free)
 

--- a/USAGE.zh-CN.md
+++ b/USAGE.zh-CN.md
@@ -49,9 +49,14 @@ cd sql2bi
 ### 4.1 启动服务
 
 ```bash
+# 终端 A
 bash services/start_backend.sh
+
+# 终端 B
 bash services/start_frontend.sh
 ```
+
+如果先开前端，页面现在会给出“backend not reachable”的明确提示，不再只有 `Load failed`。
 
 默认地址：
 - 后端：`http://127.0.0.1:18000`
@@ -69,12 +74,13 @@ curl -X POST http://127.0.0.1:18000/api/v1/import/sql-md \
   -d '{"sql_md_path":"/绝对路径/sql.md"}'
 ```
 
-示例（仓库内 demo）：
+示例（仓库内 demo，建议使用绝对路径）：
 
 ```bash
+# 把 <repo_root> 替换成你本地 sql2bi 仓库绝对路径
 curl -X POST http://127.0.0.1:18000/api/v1/import/sql-md \
   -H 'Content-Type: application/json' \
-  -d '{"sql_md_path":"/Users/bamboo/sql2bi/testdata/sql/demo.sql.md"}'
+  -d '{"sql_md_path":"<repo_root>/testdata/sql/demo.sql.md"}'
 ```
 
 导入成功后，后端会自动产出：
@@ -168,6 +174,8 @@ python3 skills/sql-to-bi-builder/scripts/parse_sql_md.py --input /绝对路径/s
 python3 skills/sql-to-bi-builder/scripts/infer_semantics.py --input /tmp/out/query_catalog.json --output /tmp/out/semantic_catalog.json
 python3 skills/sql-to-bi-builder/scripts/recommend_chart.py --input /tmp/out/semantic_catalog.json --query-catalog /tmp/out/query_catalog.json --output /tmp/out/chart_plan.json
 python3 skills/sql-to-bi-builder/scripts/build_dashboard_spec.py --queries /tmp/out/query_catalog.json --semantics /tmp/out/semantic_catalog.json --charts /tmp/out/chart_plan.json --output /tmp/out/dashboard.json
+# 若只想要语义/结构，不注入默认 UI 主题：
+python3 skills/sql-to-bi-builder/scripts/build_dashboard_spec.py --queries /tmp/out/query_catalog.json --semantics /tmp/out/semantic_catalog.json --charts /tmp/out/chart_plan.json --output /tmp/out/dashboard.min.json --without-ui-theme
 ```
 
 ### 5.4 过滤器参数语法（前后端共用）
@@ -288,10 +296,10 @@ bash services/start_backend.sh
 # 2) 启动前端
 bash services/start_frontend.sh
 
-# 3) 导入示例 SQL
+# 3) 导入示例 SQL（把 <repo_root> 换成你的本地绝对路径）
 curl -X POST http://127.0.0.1:18000/api/v1/import/sql-md \
   -H 'Content-Type: application/json' \
-  -d '{"sql_md_path":"/Users/bamboo/sql2bi/testdata/sql/demo.sql.md"}'
+  -d '{"sql_md_path":"<repo_root>/testdata/sql/demo.sql.md"}'
 
 # 4) 查看当前 dashboard
 curl http://127.0.0.1:18000/api/v1/dashboard/current

--- a/USAGE.zh-CN.md
+++ b/USAGE.zh-CN.md
@@ -1,0 +1,298 @@
+# SQL2BI 使用文档（重点：两个 Skills 的实操）
+
+## 1. 这是什么项目
+
+`sql2bi` 是一个把 `sql.md`（Markdown 中多个 SQL 块）转换为可运行 BI 原型的工作区，核心能力分两部分：
+
+1. `sql-to-bi-builder`：把 SQL 自动变成仪表盘规格、UI 和服务骨架。
+2. `starrocks-mcp-analyst`：通过 StarRocks MCP 做“可审计”的业务分析与结论输出。
+
+建议把它理解为：
+- `sql-to-bi-builder` 负责“搭建 BI 页面与服务”。
+- `starrocks-mcp-analyst` 负责“做严谨分析并产出业务结论”。
+
+规范化 Prompt 模板见：
+- [PROMPT-TEMPLATE.zh-CN.md](./PROMPT-TEMPLATE.zh-CN.md)
+
+## 2. 克隆项目
+
+```bash
+git clone https://github.com/stan2133/sql2bi.git
+cd sql2bi
+```
+
+## 3. 环境准备
+
+### 3.1 标准环境（推荐）
+
+- Python `3.11.x`
+- Node.js + npm（只在你要跑 React 前端时需要）
+
+项目约束：
+- `.python-version` 固定为 `3.11`
+- `pyproject.toml` 要求 `>=3.11,<3.12`
+
+### 3.2 快速体验环境（无需装 Node，也可缺少后端重依赖）
+
+项目启动脚本有自动降级能力：
+
+1. 后端：
+- 若检测到 `fastapi/uvicorn/duckdb/polars/pandas`，走 full 模式。
+- 否则自动走 lite 模式（`services/backend/app_lite.py`）。
+
+2. 前端：
+- 若 `services/frontend/node_modules` 存在，走 React/Vite 模式。
+- 否则自动走 lite 前端（`services/frontend-lite`）。
+
+## 4. 一次跑通（最快路径）
+
+### 4.1 启动服务
+
+```bash
+bash services/start_backend.sh
+bash services/start_frontend.sh
+```
+
+默认地址：
+- 后端：`http://127.0.0.1:18000`
+- 前端：`http://127.0.0.1:15173`
+
+可通过环境变量改端口：
+- `BACKEND_HOST` / `BACKEND_PORT`
+- `FRONTEND_HOST` / `FRONTEND_PORT`
+
+### 4.2 导入 SQL 文件
+
+```bash
+curl -X POST http://127.0.0.1:18000/api/v1/import/sql-md \
+  -H 'Content-Type: application/json' \
+  -d '{"sql_md_path":"/绝对路径/sql.md"}'
+```
+
+示例（仓库内 demo）：
+
+```bash
+curl -X POST http://127.0.0.1:18000/api/v1/import/sql-md \
+  -H 'Content-Type: application/json' \
+  -d '{"sql_md_path":"/Users/bamboo/sql2bi/testdata/sql/demo.sql.md"}'
+```
+
+导入成功后，后端会自动产出：
+- `services/backend/data/artifacts/query_catalog.json`
+- `services/backend/data/artifacts/semantic_catalog.json`
+- `services/backend/data/artifacts/chart_plan.json`
+- `services/backend/data/artifacts/dashboard.json`
+
+### 4.3 自定义更好看的 BI 页面（Theme Studio）
+
+前端右侧 `Theme Studio` 支持：
+- 主题预设（Use Dashboard Theme / Sunset Glow / Mint Pulse / Graphite Lab / Midnight Ops）
+- 主色、文本色、页面背景、面板背景
+- 圆角（Roundness）
+- 卡片阴影（Shadow）
+- 图表调色板（5 色）
+
+说明：
+- 调整结果会保存在浏览器 `localStorage`（键：`sql2bi_ui_overrides_v1`）。
+- 点击 `Reset Local Theme` 可清空本地主题覆盖，回到默认。
+- 当 `dashboard.json` 包含 `ui.theme` 与 `ui.chart_palette` 时，会作为“看板默认风格”自动加载。
+
+### 4.4 新版 UI 升级点（2026-03）
+
+为了让展示差异更明显，这一版新增：
+
+1. 顶部 KPI 汇总条（自动从每个 Widget 的 summary 提取主指标）
+- 支持最多展示 6 个 KPI 卡片
+- 点击 KPI 卡可直接聚焦到对应图表
+
+2. 布局模式切换（Toolbar）
+- `Classic`：原始多图布局
+- `Focus`：单图聚焦展示（适合会议演示）
+
+3. 深色运营风格预设
+- 新增 `Midnight Ops` 主题预设，夜间/大屏演示观感更明显
+
+4. 可视层级优化
+- KPI 卡、选中态、焦点态、背景层次做了强化
+- 图表卡 hover/active 反馈更清晰
+
+## 5. Skill 1：`sql-to-bi-builder` 实操
+
+### 5.1 输入文件格式（sql.md）
+
+每个 SQL 用一个 fenced block，建议每块前加元数据：
+
+````md
+## card: Daily GMV
+- id: daily_gmv
+- datasource: mysql_prod
+- refresh: 5m
+- chart: auto
+- filters: date, region
+
+```sql
+SELECT DATE(pay_time) AS dt, SUM(amount) AS gmv
+FROM orders
+WHERE pay_status = 'paid'
+GROUP BY 1
+ORDER BY 1;
+```
+````
+
+建议：
+- 一条逻辑查询一个 SQL block。
+- 必填稳定 `id`。
+- 字段尽量显式 `AS 别名`，否则语义推断可能得到 `col_01` 之类的回退名。
+
+### 5.2 一键 Pipeline（要求 Python 3.11）
+
+```bash
+python3.11 skills/sql-to-bi-builder/scripts/run_pipeline.py \
+  --input /绝对路径/sql.md \
+  --out /绝对路径/out \
+  --with-services
+```
+
+输出目录：
+- `out/query_catalog.json`
+- `out/semantic_catalog.json`（含 `dsl_filters`）
+- `out/chart_plan.json`
+- `out/dashboard.json`（含 `global_filters`）
+- `out/ui/`
+- `out/services/`（`--with-services` 时生成）
+
+### 5.3 分步调试（推荐排错时使用）
+
+```bash
+python3 skills/sql-to-bi-builder/scripts/parse_sql_md.py --input /绝对路径/sql.md --output /tmp/out/query_catalog.json
+python3 skills/sql-to-bi-builder/scripts/infer_semantics.py --input /tmp/out/query_catalog.json --output /tmp/out/semantic_catalog.json
+python3 skills/sql-to-bi-builder/scripts/recommend_chart.py --input /tmp/out/semantic_catalog.json --query-catalog /tmp/out/query_catalog.json --output /tmp/out/chart_plan.json
+python3 skills/sql-to-bi-builder/scripts/build_dashboard_spec.py --queries /tmp/out/query_catalog.json --semantics /tmp/out/semantic_catalog.json --charts /tmp/out/chart_plan.json --output /tmp/out/dashboard.json
+```
+
+### 5.4 过滤器参数语法（前后端共用）
+
+查询接口：`GET /api/v1/queries/{query_id}/data`
+
+支持三种过滤写法：
+- 等值：`field=value`
+- 集合：`field=a,b,c`
+- 范围：`field=from..to`
+
+示例：
+
+```bash
+curl "http://127.0.0.1:18000/api/v1/queries/daily_gmv/data?include_filters=true&region=华东,华南&dt=2024-01-01..2024-01-07"
+```
+
+## 6. Skill 2：`starrocks-mcp-analyst` 实操
+
+这个 skill 不是“画图工具”，而是“带审计门禁的业务分析流程”。
+
+### 6.1 使用前提
+
+1. 已配置可用的 StarRocks MCP 服务（至少有元数据查询、SQL 执行能力）。
+2. 有可写本地目录用于审计落盘。
+
+### 6.2 必须遵守的审计门禁
+
+每条执行 SQL 都必须同时满足：
+
+1. 落盘 SQL 文件：
+- `audit/<session_id>/sql/<query_id>.sql`
+
+2. 追加登记：
+- `audit/<session_id>/sql.md`
+
+3. `sql.md` 必备字段：
+- `query_id`
+- `状态`
+- `执行时间`
+- `耗时(ms)`
+- `返回行数`
+- `参数`
+- `SQL文件路径`
+- 完整 SQL 文本
+
+4. 失败门禁：
+- SQL 执行成功但未落盘 => `sql_audit=FAIL`，禁止发布最终结论（Step 7/8）。
+
+### 6.3 推荐操作顺序（按 skill 设计）
+
+1. 建立 Decision Card（问题、指标、时间窗、对比方式、范围）。
+2. 明确业务语义合同（指标公式、粒度、允许维度、禁用 join）。
+3. 探测 MCP 能力并建立最小数据地图（事实表、维表、join key）。
+4. 建立假设树与验证计划（证据 SQL + 反证 SQL + 对账 SQL）。
+5. 生成成套 SQL 包（不要只写单条 SQL）。
+6. 执行 SQL 审计（口径、粒度、对账、质量、性能）。
+7. 输出洞察与影响评估（事实/解释/建议分离）。
+8. 执行报告审计并发布。
+
+### 6.4 首次可直接复用的提问模板
+
+```text
+请使用 starrocks-mcp-analyst skill 分析：
+1) 决策问题：是否应在下月增加 US 区域 paid social 预算？
+2) 目标指标：incremental_gmv
+3) 分析窗口：2026-02-01 到 2026-02-28，按 day
+4) 对比方式：period_over_period
+5) 范围：channel=paid_social, region=US, segment=new_users
+
+要求：
+- 严格执行 8 步流程
+- 每条 SQL 必须落盘到 audit/<session_id>/sql/ 并登记 audit/<session_id>/sql.md
+- 审计叙述使用中文
+- 输出 sql_audit 与 report_audit
+```
+
+## 7. 两个 Skills 如何配合
+
+推荐组合流程：
+
+1. 用 `starrocks-mcp-analyst` 产出高质量、可复核 SQL 包（带审计记录）。
+2. 把稳定 SQL 汇总成 `sql.md`。
+3. 用 `sql-to-bi-builder` 生成 dashboard + 服务 + UI。
+4. 前端演示，后端接口联调，形成“可解释 + 可展示”的分析交付。
+
+## 8. 常见问题
+
+### 8.1 `python3.11 not found in PATH`
+
+这是最常见问题。可先走 lite 模式快速体验，或安装 3.11 后再跑标准 pipeline。
+
+### 8.2 前端打开后提示 Backend unavailable
+
+检查：
+1. 后端是否已启动。
+2. 前端中的 backend 地址是否是 `http://127.0.0.1:18000`（或你自定义端口）。
+3. `Import sql.md` 的路径是否为绝对路径且文件存在。
+
+### 8.3 为什么图里字段名变成 `col_01`
+
+SQL 列缺少显式别名时会发生。请把关键字段改成 `AS xxx`。
+
+### 8.4 导入成功但想看可用过滤器
+
+调用：
+
+```bash
+curl http://127.0.0.1:18000/api/v1/filters
+```
+
+## 9. 你可以直接执行的最小命令清单
+
+```bash
+# 1) 启动后端
+bash services/start_backend.sh
+
+# 2) 启动前端
+bash services/start_frontend.sh
+
+# 3) 导入示例 SQL
+curl -X POST http://127.0.0.1:18000/api/v1/import/sql-md \
+  -H 'Content-Type: application/json' \
+  -d '{"sql_md_path":"/Users/bamboo/sql2bi/testdata/sql/demo.sql.md"}'
+
+# 4) 查看当前 dashboard
+curl http://127.0.0.1:18000/api/v1/dashboard/current
+```

--- a/scripts/check-requirements-version.sh
+++ b/scripts/check-requirements-version.sh
@@ -23,7 +23,7 @@ is_pinned_line() {
 extract_pyyaml_version() {
   local file="$1"
   local version
-  version="$(rg '^PyYAML==[0-9][0-9A-Za-z._+-]*$' "$file" -o | sed -E 's/^PyYAML==//' | head -n1 || true)"
+  version="$(grep -E '^PyYAML==[0-9][0-9A-Za-z._+-]*$' "$file" | sed -E 's/^PyYAML==//' | head -n1 || true)"
   echo "$version"
 }
 
@@ -54,7 +54,7 @@ elif [[ "$root_pyyaml" != "$skill_pyyaml" ]]; then
 fi
 
 if [[ -n "$root_pyyaml" ]]; then
-  if ! rg -n "PyYAML==$root_pyyaml" pyproject.toml >/dev/null 2>&1; then
+  if ! grep -nF "PyYAML==$root_pyyaml" pyproject.toml >/dev/null 2>&1; then
     echo "[requirements-check] pyproject.toml dev dependency must pin PyYAML==$root_pyyaml" >&2
     fail=1
   fi

--- a/services/frontend/src/App.tsx
+++ b/services/frontend/src/App.tsx
@@ -7,21 +7,380 @@ import type {
   FilterValue,
   FiltersPayload,
   QueryDataPayload,
+  ThemeSpec,
+  UiSpec,
   WidgetSpec
 } from './types'
 
 const DEFAULT_BACKEND_URL = 'http://127.0.0.1:18000'
-const DEFAULT_SQL_MD_PATH = '/Users/lyg/software/sql2bi/sample.sql.md'
+const DEFAULT_SQL_MD_PATH = '/abs/path/sql.md'
+const UI_OVERRIDES_KEY = 'sql2bi_ui_overrides_v1'
+const LAYOUT_MODE_KEY = 'sql2bi_layout_mode_v1'
+const ECHARTS_THEME_NAME = 'sql2bi_dynamic_theme_v1'
+
+const HEX_COLOR_RE = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/
+
+type UiPreset = 'dashboard' | 'sunset' | 'mint' | 'graphite' | 'midnight'
+type LayoutMode = 'classic' | 'focus'
+
+type UiOverrides = {
+  preset: UiPreset
+  theme: Partial<ThemeSpec>
+  chart_palette: string[]
+  shadow_level: number | null
+}
+
+type ThemePresetDef = {
+  label: string
+  ui: UiSpec
+}
+
+type ResolvedTheme = {
+  name: string
+  font_family: string
+  app_bg: string
+  canvas_bg: string
+  panel_bg: string
+  line_soft: string
+  line_strong: string
+  text_main: string
+  text_sub: string
+  text_mute: string
+  brand: string
+  brand_weak: string
+  radius_sm: number
+  radius_md: number
+  card_shadow: string
+}
+
+type WidgetVisual = {
+  palette: string[]
+  textMain: string
+  textSub: string
+  textMute: string
+  brand: string
+  lineSoft: string
+  lineStrong: string
+}
 
 type WidgetCardProps = {
   widget: WidgetSpec
   payload?: QueryDataPayload
   active: boolean
+  themeName: string
+  visual: WidgetVisual
   onClick: () => void
   onCrossFilter: (value: string) => void
 }
 
-function optionForPayload(payload: QueryDataPayload): echarts.EChartsOption | null {
+const DEFAULT_THEME: ResolvedTheme = {
+  name: 'studio_default',
+  font_family: '"Source Sans 3", "Noto Sans SC", sans-serif',
+  app_bg: '#f5f7fb',
+  canvas_bg: '#eef2ff',
+  panel_bg: '#ffffff',
+  line_soft: '#dce4f3',
+  line_strong: '#c7d4ec',
+  text_main: '#0f172a',
+  text_sub: '#334155',
+  text_mute: '#64748b',
+  brand: '#0ea5e9',
+  brand_weak: '#e0f2fe',
+  radius_sm: 8,
+  radius_md: 14,
+  card_shadow: '0 10px 28px rgba(15, 23, 42, 0.08)'
+}
+
+const DEFAULT_CHART_PALETTE = ['#0ea5e9', '#f59e0b', '#14b8a6', '#f43f5e', '#8b5cf6']
+
+const THEME_PRESETS: Record<Exclude<UiPreset, 'dashboard'>, ThemePresetDef> = {
+  sunset: {
+    label: 'Sunset Glow',
+    ui: {
+      theme: {
+        name: 'sunset_glow',
+        app_bg: '#fff7ed',
+        canvas_bg: '#ffedd5',
+        panel_bg: '#ffffff',
+        line_soft: '#fed7aa',
+        line_strong: '#fdba74',
+        text_main: '#7c2d12',
+        text_sub: '#9a3412',
+        text_mute: '#b45309',
+        brand: '#f97316',
+        brand_weak: '#ffedd5',
+        radius_sm: 10,
+        radius_md: 16,
+        card_shadow: '0 12px 28px rgba(154, 52, 18, 0.16)'
+      },
+      chart_palette: ['#f97316', '#fb7185', '#f59e0b', '#2dd4bf', '#a855f7']
+    }
+  },
+  mint: {
+    label: 'Mint Pulse',
+    ui: {
+      theme: {
+        name: 'mint_pulse',
+        app_bg: '#f0fdfa',
+        canvas_bg: '#d1fae5',
+        panel_bg: '#ffffff',
+        line_soft: '#a7f3d0',
+        line_strong: '#6ee7b7',
+        text_main: '#064e3b',
+        text_sub: '#065f46',
+        text_mute: '#047857',
+        brand: '#10b981',
+        brand_weak: '#d1fae5',
+        radius_sm: 9,
+        radius_md: 15,
+        card_shadow: '0 10px 24px rgba(4, 120, 87, 0.14)'
+      },
+      chart_palette: ['#10b981', '#0ea5e9', '#f59e0b', '#ef4444', '#6366f1']
+    }
+  },
+  graphite: {
+    label: 'Graphite Lab',
+    ui: {
+      theme: {
+        name: 'graphite_lab',
+        app_bg: '#f8fafc',
+        canvas_bg: '#e2e8f0',
+        panel_bg: '#ffffff',
+        line_soft: '#cbd5e1',
+        line_strong: '#94a3b8',
+        text_main: '#111827',
+        text_sub: '#1f2937',
+        text_mute: '#475569',
+        brand: '#2563eb',
+        brand_weak: '#dbeafe',
+        radius_sm: 7,
+        radius_md: 12,
+        card_shadow: '0 10px 24px rgba(15, 23, 42, 0.14)'
+      },
+      chart_palette: ['#2563eb', '#0891b2', '#f59e0b', '#db2777', '#16a34a']
+    }
+  },
+  midnight: {
+    label: 'Midnight Ops',
+    ui: {
+      theme: {
+        name: 'midnight_ops',
+        app_bg: '#0b1220',
+        canvas_bg: '#111827',
+        panel_bg: '#172033',
+        line_soft: '#25324a',
+        line_strong: '#334766',
+        text_main: '#e5edf8',
+        text_sub: '#b5c5df',
+        text_mute: '#8aa0c0',
+        brand: '#22d3ee',
+        brand_weak: '#0c4a6e',
+        radius_sm: 8,
+        radius_md: 14,
+        card_shadow: '0 14px 28px rgba(2, 6, 23, 0.42)'
+      },
+      chart_palette: ['#22d3ee', '#a78bfa', '#f59e0b', '#34d399', '#fb7185']
+    }
+  }
+}
+
+const DEFAULT_UI_OVERRIDES: UiOverrides = {
+  preset: 'dashboard',
+  theme: {},
+  chart_palette: [],
+  shadow_level: null
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
+function isUiPreset(value: string): value is UiPreset {
+  return value === 'dashboard' || value === 'sunset' || value === 'mint' || value === 'graphite' || value === 'midnight'
+}
+
+function isLayoutMode(value: string): value is LayoutMode {
+  return value === 'classic' || value === 'focus'
+}
+
+function normalizeHexColor(value: string | undefined, fallback: string): string {
+  if (!value) return fallback
+  const text = value.trim()
+  if (!HEX_COLOR_RE.test(text)) return fallback
+  if (text.length === 4) {
+    const r = text[1]
+    const g = text[2]
+    const b = text[3]
+    return `#${r}${r}${g}${g}${b}${b}`.toLowerCase()
+  }
+  return text.toLowerCase()
+}
+
+function hexToRgb(hex: string): { r: number; g: number; b: number } | null {
+  const normalized = normalizeHexColor(hex, '')
+  if (!normalized) return null
+  const m = /^#([0-9a-f]{6})$/i.exec(normalized)
+  if (!m) return null
+  const num = Number.parseInt(m[1], 16)
+  return {
+    r: (num >> 16) & 255,
+    g: (num >> 8) & 255,
+    b: num & 255
+  }
+}
+
+function withAlpha(hex: string, alpha: number, fallback: string): string {
+  const rgb = hexToRgb(hex)
+  if (!rgb) return fallback
+  return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${clamp(alpha, 0, 1)})`
+}
+
+function isColorDark(hex: string): boolean {
+  const rgb = hexToRgb(hex)
+  if (!rgb) return false
+  const brightness = (rgb.r * 299 + rgb.g * 587 + rgb.b * 114) / 1000
+  return brightness < 145
+}
+
+function formatKpiValue(value: number): string {
+  if (!Number.isFinite(value)) return '-'
+  if (Math.abs(value) >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`
+  if (Math.abs(value) >= 1_000) return `${(value / 1_000).toFixed(1)}K`
+  return String(Math.round(value * 100) / 100)
+}
+
+function normalizePalette(source: string[] | undefined, fallback: string[] = DEFAULT_CHART_PALETTE): string[] {
+  const pool = (source || []).map((c, idx) => normalizeHexColor(c, fallback[idx % fallback.length])).slice(0, 5)
+  while (pool.length < 5) {
+    pool.push(fallback[pool.length % fallback.length])
+  }
+  return pool
+}
+
+function mergeTheme(...parts: Array<Partial<ThemeSpec> | undefined>): ResolvedTheme {
+  const raw: Partial<ThemeSpec> = {}
+  parts.forEach((part) => {
+    if (!part) return
+    Object.assign(raw, part)
+  })
+
+  const brand = normalizeHexColor(raw.brand, DEFAULT_THEME.brand)
+  const brandWeakFallback = withAlpha(brand, 0.14, DEFAULT_THEME.brand_weak)
+
+  return {
+    name: String(raw.name || DEFAULT_THEME.name),
+    font_family: String(raw.font_family || DEFAULT_THEME.font_family),
+    app_bg: normalizeHexColor(raw.app_bg, DEFAULT_THEME.app_bg),
+    canvas_bg: normalizeHexColor(raw.canvas_bg, DEFAULT_THEME.canvas_bg),
+    panel_bg: normalizeHexColor(raw.panel_bg, DEFAULT_THEME.panel_bg),
+    line_soft: normalizeHexColor(raw.line_soft, DEFAULT_THEME.line_soft),
+    line_strong: normalizeHexColor(raw.line_strong, DEFAULT_THEME.line_strong),
+    text_main: normalizeHexColor(raw.text_main, DEFAULT_THEME.text_main),
+    text_sub: normalizeHexColor(raw.text_sub, DEFAULT_THEME.text_sub),
+    text_mute: normalizeHexColor(raw.text_mute, DEFAULT_THEME.text_mute),
+    brand,
+    brand_weak: normalizeHexColor(raw.brand_weak, brandWeakFallback),
+    radius_sm: clamp(Number(raw.radius_sm ?? DEFAULT_THEME.radius_sm), 4, 24),
+    radius_md: clamp(Number(raw.radius_md ?? DEFAULT_THEME.radius_md), 8, 28),
+    card_shadow: String(raw.card_shadow || DEFAULT_THEME.card_shadow)
+  }
+}
+
+function buildCardShadow(level: number): string {
+  if (level <= 0) return 'none'
+  const y = Math.max(2, Math.round(level * 0.45))
+  const blur = Math.max(8, Math.round(level * 2.6))
+  const alpha = Math.min(0.22, 0.04 + level * 0.007)
+  return `0 ${y}px ${blur}px rgba(15, 23, 42, ${alpha.toFixed(3)})`
+}
+
+function loadUiOverrides(): UiOverrides {
+  try {
+    const raw = localStorage.getItem(UI_OVERRIDES_KEY)
+    if (!raw) return DEFAULT_UI_OVERRIDES
+
+    const parsed = JSON.parse(raw) as Partial<UiOverrides>
+    const preset = typeof parsed.preset === 'string' && isUiPreset(parsed.preset) ? parsed.preset : 'dashboard'
+    const theme = parsed.theme && typeof parsed.theme === 'object' ? parsed.theme : {}
+    const palette = Array.isArray(parsed.chart_palette) ? parsed.chart_palette.filter((v): v is string => typeof v === 'string') : []
+    const shadowLevel =
+      typeof parsed.shadow_level === 'number' && Number.isFinite(parsed.shadow_level)
+        ? clamp(Math.round(parsed.shadow_level), 0, 24)
+        : null
+
+    return {
+      preset,
+      theme,
+      chart_palette: palette,
+      shadow_level: shadowLevel
+    }
+  } catch {
+    return DEFAULT_UI_OVERRIDES
+  }
+}
+
+function loadLayoutMode(): LayoutMode {
+  const raw = localStorage.getItem(LAYOUT_MODE_KEY)
+  return raw && isLayoutMode(raw) ? raw : 'classic'
+}
+
+function buildEchartsTheme(theme: ResolvedTheme, palette: string[]): Record<string, unknown> {
+  return {
+    color: palette,
+    backgroundColor: 'transparent',
+    textStyle: {
+      color: theme.text_sub,
+      fontFamily: theme.font_family
+    },
+    legend: {
+      textStyle: {
+        color: theme.text_sub
+      }
+    },
+    categoryAxis: {
+      axisLine: {
+        lineStyle: {
+          color: theme.line_strong
+        }
+      },
+      axisLabel: {
+        color: theme.text_sub
+      },
+      splitLine: {
+        lineStyle: {
+          color: theme.line_soft
+        }
+      }
+    },
+    valueAxis: {
+      axisLine: {
+        lineStyle: {
+          color: theme.line_strong
+        }
+      },
+      axisLabel: {
+        color: theme.text_sub
+      },
+      splitLine: {
+        lineStyle: {
+          color: theme.line_soft
+        }
+      }
+    },
+    line: {
+      lineStyle: { width: 2.2 },
+      symbol: 'circle',
+      symbolSize: 6
+    },
+    bar: {
+      itemStyle: {
+        borderRadius: [6, 6, 0, 0]
+      }
+    }
+  }
+}
+
+function optionForPayload(payload: QueryDataPayload, visual: WidgetVisual): echarts.EChartsOption | null {
   const chartType = (payload.chart || 'table').toLowerCase()
   const rows = payload.rows || []
   const dim = payload.dimension
@@ -32,36 +391,43 @@ function optionForPayload(payload: QueryDataPayload): echarts.EChartsOption | nu
   const y1 = rows.map((r) => Number(r[metricA] || 0))
   const y2 = rows.map((r) => Number(r[metricB] || 0))
 
+  const axis = {
+    axisLabel: { color: visual.textSub },
+    axisLine: { lineStyle: { color: visual.lineStrong } }
+  }
+
   if (chartType === 'line') {
     return {
-      color: ['#2f6fed'],
-      tooltip: { trigger: 'axis' },
+      color: visual.palette,
+      tooltip: {
+        trigger: 'axis'
+      },
       grid: { left: 36, right: 12, top: 18, bottom: 24 },
-      xAxis: { type: 'category', data: x },
-      yAxis: { type: 'value' },
+      xAxis: { type: 'category', data: x, ...axis },
+      yAxis: { type: 'value', ...axis, splitLine: { lineStyle: { color: visual.lineSoft } } },
       series: [{ type: 'line', smooth: true, data: y1 }]
     }
   }
 
   if (chartType === 'bar') {
     return {
-      color: ['#2f6fed'],
+      color: visual.palette,
       tooltip: { trigger: 'axis' },
       grid: { left: 36, right: 12, top: 18, bottom: 24 },
-      xAxis: { type: 'category', data: x, axisLabel: { rotate: 25 } },
-      yAxis: { type: 'value' },
+      xAxis: { type: 'category', data: x, axisLabel: { rotate: 25, color: visual.textSub }, axisLine: axis.axisLine },
+      yAxis: { type: 'value', ...axis, splitLine: { lineStyle: { color: visual.lineSoft } } },
       series: [{ type: 'bar', data: y1 }]
     }
   }
 
   if (chartType === 'grouped_bar') {
     return {
-      color: ['#2f6fed', '#f59e0b'],
+      color: visual.palette,
       tooltip: { trigger: 'axis' },
-      legend: { top: 0 },
+      legend: { top: 0, textStyle: { color: visual.textSub } },
       grid: { left: 36, right: 12, top: 24, bottom: 24 },
-      xAxis: { type: 'category', data: x, axisLabel: { rotate: 20 } },
-      yAxis: { type: 'value' },
+      xAxis: { type: 'category', data: x, axisLabel: { rotate: 20, color: visual.textSub }, axisLine: axis.axisLine },
+      yAxis: { type: 'value', ...axis, splitLine: { lineStyle: { color: visual.lineSoft } } },
       series: [
         { name: metricA, type: 'bar', data: y1 },
         { name: metricB, type: 'bar', data: y2 }
@@ -74,19 +440,19 @@ function optionForPayload(payload: QueryDataPayload): echarts.EChartsOption | nu
     return {
       xAxis: { show: false, type: 'value' },
       yAxis: { show: false, type: 'value' },
-      series: [{ type: 'bar', data: [total], barWidth: 80, itemStyle: { color: '#2f6fed' } }],
+      series: [{ type: 'bar', data: [total], barWidth: 80, itemStyle: { color: visual.brand } }],
       graphic: [
         {
           type: 'text',
           left: 'center',
           top: '44%',
-          style: { text: String(total), font: '700 24px "JetBrains Mono"', fill: '#101828' }
+          style: { text: String(total), font: '700 24px "JetBrains Mono"', fill: visual.textMain }
         },
         {
           type: 'text',
           left: 'center',
           top: '63%',
-          style: { text: metricA, font: '12px "Source Sans 3"', fill: '#667085' }
+          style: { text: metricA, font: '12px "Source Sans 3"', fill: visual.textMute }
         }
       ]
     }
@@ -95,9 +461,10 @@ function optionForPayload(payload: QueryDataPayload): echarts.EChartsOption | nu
   return null
 }
 
-function WidgetCard({ widget, payload, active, onClick, onCrossFilter }: WidgetCardProps) {
+function WidgetCard({ widget, payload, active, themeName, visual, onClick, onCrossFilter }: WidgetCardProps) {
   const chartRef = useRef<HTMLDivElement | null>(null)
   const echartsRef = useRef<echarts.ECharts | null>(null)
+  const chartThemeNameRef = useRef<string>('')
 
   useEffect(() => {
     const chartType = (widget.chart || 'table').toLowerCase()
@@ -112,8 +479,12 @@ function WidgetCard({ widget, payload, active, onClick, onCrossFilter }: WidgetC
     const node = chartRef.current
     if (!node || !payload) return
 
-    if (!echartsRef.current) {
-      echartsRef.current = echarts.init(node)
+    if (!echartsRef.current || chartThemeNameRef.current !== themeName) {
+      if (echartsRef.current) {
+        echartsRef.current.dispose()
+      }
+      echartsRef.current = echarts.init(node, themeName)
+      chartThemeNameRef.current = themeName
       echartsRef.current.on('click', (params) => {
         const name = params?.name
         if (name !== null && name !== undefined) {
@@ -122,7 +493,7 @@ function WidgetCard({ widget, payload, active, onClick, onCrossFilter }: WidgetC
       })
     }
 
-    const option = optionForPayload(payload)
+    const option = optionForPayload(payload, visual)
     if (option) {
       echartsRef.current.setOption(option, true)
       echartsRef.current.resize()
@@ -135,7 +506,7 @@ function WidgetCard({ widget, payload, active, onClick, onCrossFilter }: WidgetC
     return () => {
       window.removeEventListener('resize', onResize)
     }
-  }, [widget.chart, payload, onCrossFilter])
+  }, [widget.chart, payload, themeName, visual, onCrossFilter])
 
   useEffect(() => {
     return () => {
@@ -226,11 +597,129 @@ function App() {
   const [selectedQueryId, setSelectedQueryId] = useState<string | null>(null)
   const [loading, setLoading] = useState<boolean>(false)
   const [error, setError] = useState<string>('')
+  const [uiOverrides, setUiOverrides] = useState<UiOverrides>(() => loadUiOverrides())
+  const [layoutMode, setLayoutMode] = useState<LayoutMode>(() => loadLayoutMode())
 
   const api = useMemo(() => new Sql2BiApi(backendUrl), [backendUrl])
 
   const currentPage = dashboard?.pages?.[0]
   const widgets = currentPage?.widgets || []
+  const dashboardUi = dashboard?.ui
+  const selectedWidget = widgets.find((w) => w.query_id === selectedQueryId) || null
+  const worksheetFilters = selectedQueryId ? (filtersPayload.widget_filters[selectedQueryId] || []) : []
+
+  const presetUi = useMemo(() => {
+    if (uiOverrides.preset === 'dashboard') return undefined
+    return THEME_PRESETS[uiOverrides.preset].ui
+  }, [uiOverrides.preset])
+
+  const baseTheme = useMemo(() => {
+    if (uiOverrides.preset === 'dashboard') {
+      return mergeTheme(DEFAULT_THEME, dashboardUi?.theme)
+    }
+    return mergeTheme(DEFAULT_THEME, presetUi?.theme)
+  }, [dashboardUi?.theme, presetUi?.theme, uiOverrides.preset])
+
+  const activeTheme = useMemo(() => {
+    const merged = mergeTheme(baseTheme, uiOverrides.theme)
+    if (uiOverrides.shadow_level !== null) {
+      return {
+        ...merged,
+        card_shadow: buildCardShadow(uiOverrides.shadow_level)
+      }
+    }
+    return merged
+  }, [baseTheme, uiOverrides.shadow_level, uiOverrides.theme])
+
+  const basePalette = useMemo(() => {
+    if (uiOverrides.preset === 'dashboard') {
+      return normalizePalette(dashboardUi?.chart_palette, DEFAULT_CHART_PALETTE)
+    }
+    return normalizePalette(presetUi?.chart_palette, DEFAULT_CHART_PALETTE)
+  }, [dashboardUi?.chart_palette, presetUi?.chart_palette, uiOverrides.preset])
+
+  const activePalette = useMemo(
+    () => normalizePalette(uiOverrides.chart_palette.length ? uiOverrides.chart_palette : basePalette, basePalette),
+    [basePalette, uiOverrides.chart_palette]
+  )
+
+  const themePreviewPalette = useMemo(() => normalizePalette(activePalette, DEFAULT_CHART_PALETTE), [activePalette])
+
+  const echartsTheme = useMemo(() => buildEchartsTheme(activeTheme, activePalette), [activeTheme, activePalette])
+
+  const widgetVisual = useMemo<WidgetVisual>(
+    () => ({
+      palette: activePalette,
+      textMain: activeTheme.text_main,
+      textSub: activeTheme.text_sub,
+      textMute: activeTheme.text_mute,
+      brand: activeTheme.brand,
+      lineSoft: activeTheme.line_soft,
+      lineStrong: activeTheme.line_strong
+    }),
+    [activePalette, activeTheme]
+  )
+
+  const darkTheme = useMemo(() => isColorDark(activeTheme.app_bg), [activeTheme.app_bg])
+
+  const kpiCards = useMemo(() => {
+    return widgets
+      .map((widget) => {
+        const payload = widgetData[widget.query_id]
+        if (!payload) return null
+        const metricName = payload.metrics?.[0]
+        if (!metricName) return null
+        const rawValue = Number(payload.summary?.[metricName] ?? 0)
+        return {
+          queryId: widget.query_id,
+          label: widget.title || widget.query_id,
+          metricName,
+          value: rawValue,
+          text: formatKpiValue(rawValue)
+        }
+      })
+      .filter((item): item is { queryId: string; label: string; metricName: string; value: number; text: string } => Boolean(item))
+      .sort((a, b) => b.value - a.value)
+      .slice(0, 6)
+  }, [widgetData, widgets])
+
+  const visibleWidgets = useMemo(() => {
+    if (layoutMode !== 'focus') return widgets
+    if (!selectedQueryId) return widgets
+    return widgets.filter((w) => w.query_id === selectedQueryId)
+  }, [layoutMode, selectedQueryId, widgets])
+
+  useEffect(() => {
+    localStorage.setItem(UI_OVERRIDES_KEY, JSON.stringify(uiOverrides))
+  }, [uiOverrides])
+
+  useEffect(() => {
+    localStorage.setItem(LAYOUT_MODE_KEY, layoutMode)
+  }, [layoutMode])
+
+  useEffect(() => {
+    const root = document.documentElement
+    root.style.setProperty('--bg-app', activeTheme.app_bg)
+    root.style.setProperty('--bg-canvas', activeTheme.canvas_bg)
+    root.style.setProperty('--bg-panel', activeTheme.panel_bg)
+    root.style.setProperty('--line-soft', activeTheme.line_soft)
+    root.style.setProperty('--line-strong', activeTheme.line_strong)
+    root.style.setProperty('--text-main', activeTheme.text_main)
+    root.style.setProperty('--text-sub', activeTheme.text_sub)
+    root.style.setProperty('--text-mute', activeTheme.text_mute)
+    root.style.setProperty('--brand', activeTheme.brand)
+    root.style.setProperty('--brand-weak', activeTheme.brand_weak)
+    root.style.setProperty('--radius-sm', `${activeTheme.radius_sm}px`)
+    root.style.setProperty('--radius-md', `${activeTheme.radius_md}px`)
+    root.style.setProperty('--card-shadow', activeTheme.card_shadow)
+    root.style.setProperty('--font-family-main', activeTheme.font_family)
+    root.style.setProperty('--brand-ring', withAlpha(activeTheme.brand, 0.2, 'rgba(14, 165, 233, 0.2)'))
+    root.style.setProperty('--brand-glow', withAlpha(activeTheme.brand, 0.12, 'rgba(14, 165, 233, 0.12)'))
+  }, [activeTheme])
+
+  useEffect(() => {
+    echarts.registerTheme(ECHARTS_THEME_NAME, echartsTheme)
+  }, [echartsTheme])
 
   const loadDashboard = useCallback(async () => {
     setLoading(true)
@@ -309,11 +798,46 @@ function App() {
     }
   }, [api, loadDashboard, sqlPath])
 
-  const selectedWidget = widgets.find((w) => w.query_id === selectedQueryId) || null
-  const worksheetFilters = selectedQueryId ? (filtersPayload.widget_filters[selectedQueryId] || []) : []
+  const updateThemePatch = useCallback((patch: Partial<ThemeSpec>) => {
+    setUiOverrides((prev) => ({
+      ...prev,
+      theme: {
+        ...prev.theme,
+        ...patch
+      }
+    }))
+  }, [])
+
+  const onPresetChange = useCallback((nextPresetText: string) => {
+    const preset: UiPreset = isUiPreset(nextPresetText) ? nextPresetText : 'dashboard'
+    const presetPalette = preset === 'dashboard' ? [] : normalizePalette(THEME_PRESETS[preset].ui.chart_palette)
+    setUiOverrides({
+      preset,
+      theme: {},
+      chart_palette: presetPalette,
+      shadow_level: null
+    })
+  }, [])
+
+  const onPaletteChange = useCallback((index: number, color: string) => {
+    const normalized = normalizeHexColor(color, DEFAULT_CHART_PALETTE[index % DEFAULT_CHART_PALETTE.length])
+    setUiOverrides((prev) => {
+      const nextPalette = normalizePalette(prev.chart_palette.length ? prev.chart_palette : activePalette)
+      nextPalette[index] = normalized
+      return {
+        ...prev,
+        chart_palette: nextPalette
+      }
+    })
+  }, [activePalette])
+
+  const resetLocalTheme = useCallback(() => {
+    setUiOverrides(DEFAULT_UI_OVERRIDES)
+    localStorage.removeItem(UI_OVERRIDES_KEY)
+  }, [])
 
   return (
-    <div className="app-root">
+    <div className={`app-root ${darkTheme ? 'theme-dark' : ''} layout-${layoutMode}`}>
       <header className="top-toolbar">
         <div className="toolbar-left">
           <div className="brand">SQL2BI Service UI</div>
@@ -328,6 +852,10 @@ function App() {
         </div>
         <div className="toolbar-right">
           <div className="sql-row">
+            <select value={layoutMode} onChange={(e) => setLayoutMode(isLayoutMode(e.target.value) ? e.target.value : 'classic')}>
+              <option value="classic">Layout: Classic</option>
+              <option value="focus">Layout: Focus</option>
+            </select>
             <input value={sqlPath} onChange={(e) => setSqlPath(e.target.value)} placeholder="/abs/path/sql.md" />
             <button onClick={importSqlMd} disabled={loading}>Import sql.md</button>
             <button onClick={() => loadDashboard()} disabled={loading}>Reload</button>
@@ -358,18 +886,40 @@ function App() {
           <div className="headline">
             <h1>{dashboard?.name || 'No dashboard loaded'}</h1>
             <div className="subline">
-              {widgets.length} widgets
+              {widgets.length} widgets · mode: {layoutMode}
               {loading ? ' | loading...' : ''}
               {error ? ` | error: ${error}` : ''}
             </div>
           </div>
-          <section className="grid-canvas">
-            {widgets.map((w) => (
+
+          {kpiCards.length > 0 ? (
+            <section className="kpi-strip">
+              {kpiCards.map((item) => (
+                <button
+                  key={`kpi-${item.queryId}`}
+                  className={`kpi-card ${selectedQueryId === item.queryId ? 'active' : ''}`}
+                  onClick={() => {
+                    setSelectedQueryId(item.queryId)
+                    setLayoutMode('focus')
+                  }}
+                >
+                  <span className="kpi-label">{item.label}</span>
+                  <span className="kpi-value">{item.text}</span>
+                  <span className="kpi-metric">{item.metricName}</span>
+                </button>
+              ))}
+            </section>
+          ) : null}
+
+          <section className={`grid-canvas ${layoutMode === 'focus' ? 'focus-mode' : ''}`}>
+            {visibleWidgets.map((w) => (
               <WidgetCard
                 key={w.id}
                 widget={w}
                 payload={widgetData[w.query_id]}
                 active={selectedQueryId === w.query_id}
+                themeName={ECHARTS_THEME_NAME}
+                visual={widgetVisual}
                 onClick={() => setSelectedQueryId(w.query_id)}
                 onCrossFilter={(value) => {
                   const target = (filtersPayload.global_filters || [])[0]
@@ -382,6 +932,115 @@ function App() {
         </main>
 
         <aside className="right-pane">
+          <div className="theme-studio">
+            <div className="pane-title">Theme Studio</div>
+
+            <div className="theme-field">
+              <label>Preset</label>
+              <select value={uiOverrides.preset} onChange={(e) => onPresetChange(e.target.value)}>
+                <option value="dashboard">Use Dashboard Theme</option>
+                <option value="sunset">{THEME_PRESETS.sunset.label}</option>
+                <option value="mint">{THEME_PRESETS.mint.label}</option>
+                <option value="graphite">{THEME_PRESETS.graphite.label}</option>
+                <option value="midnight">{THEME_PRESETS.midnight.label}</option>
+              </select>
+            </div>
+
+            <div className="theme-row">
+              <div className="theme-field">
+                <label>Brand</label>
+                <input
+                  type="color"
+                  value={normalizeHexColor(activeTheme.brand, DEFAULT_THEME.brand)}
+                  onChange={(e) => updateThemePatch({ brand: e.target.value, brand_weak: undefined })}
+                />
+              </div>
+              <div className="theme-field">
+                <label>Text</label>
+                <input
+                  type="color"
+                  value={normalizeHexColor(activeTheme.text_main, DEFAULT_THEME.text_main)}
+                  onChange={(e) => updateThemePatch({ text_main: e.target.value })}
+                />
+              </div>
+            </div>
+
+            <div className="theme-row">
+              <div className="theme-field">
+                <label>App Bg</label>
+                <input
+                  type="color"
+                  value={normalizeHexColor(activeTheme.app_bg, DEFAULT_THEME.app_bg)}
+                  onChange={(e) => updateThemePatch({ app_bg: e.target.value })}
+                />
+              </div>
+              <div className="theme-field">
+                <label>Panel Bg</label>
+                <input
+                  type="color"
+                  value={normalizeHexColor(activeTheme.panel_bg, DEFAULT_THEME.panel_bg)}
+                  onChange={(e) => updateThemePatch({ panel_bg: e.target.value })}
+                />
+              </div>
+            </div>
+
+            <div className="theme-slider">
+              <label>Roundness ({Math.round(activeTheme.radius_md)}px)</label>
+              <input
+                type="range"
+                min={8}
+                max={24}
+                value={Math.round(activeTheme.radius_md)}
+                onChange={(e) => {
+                  const radiusMd = clamp(Number(e.target.value), 8, 24)
+                  updateThemePatch({
+                    radius_md: radiusMd,
+                    radius_sm: Math.max(4, radiusMd - 6)
+                  })
+                }}
+              />
+            </div>
+
+            <div className="theme-slider">
+              <label>Shadow ({uiOverrides.shadow_level ?? 10})</label>
+              <input
+                type="range"
+                min={0}
+                max={24}
+                value={uiOverrides.shadow_level ?? 10}
+                onChange={(e) => {
+                  const value = clamp(Number(e.target.value), 0, 24)
+                  setUiOverrides((prev) => ({ ...prev, shadow_level: value }))
+                }}
+              />
+            </div>
+
+            <div className="theme-field">
+              <label>Chart Palette</label>
+              <div className="palette-strip">
+                {themePreviewPalette.map((color, idx) => (
+                  <div className="palette-item" key={`palette-${idx}`}>
+                    <span>{idx + 1}</span>
+                    <input
+                      type="color"
+                      value={normalizeHexColor(color, DEFAULT_CHART_PALETTE[idx])}
+                      onChange={(e) => onPaletteChange(idx, e.target.value)}
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="theme-actions">
+              <button onClick={resetLocalTheme}>Reset Local Theme</button>
+              <button
+                onClick={() => setUiOverrides((prev) => ({ ...prev, chart_palette: [] }))}
+              >
+                Reset Palette
+              </button>
+            </div>
+          </div>
+
           <div className="pane-title">Worksheet Filters</div>
           {selectedWidget ? (
             <>

--- a/services/frontend/src/App.tsx
+++ b/services/frontend/src/App.tsx
@@ -8,50 +8,34 @@ import type {
   FiltersPayload,
   QueryDataPayload,
   ThemeSpec,
-  UiSpec,
   WidgetSpec
 } from './types'
+import {
+  DEFAULT_CHART_PALETTE,
+  DEFAULT_THEME,
+  DEFAULT_UI_OVERRIDES,
+  THEME_PRESETS,
+  buildCardShadow,
+  clamp,
+  formatKpiValue,
+  isColorDark,
+  isLayoutMode,
+  isUiPreset,
+  mergeTheme,
+  normalizeHexColor,
+  normalizePalette,
+  withAlpha,
+  type LayoutMode,
+  type UiOverrides,
+  type UiPreset
+} from './theme/themeUtils'
+import { buildEchartsTheme } from './theme/echartsTheme'
 
 const DEFAULT_BACKEND_URL = 'http://127.0.0.1:18000'
 const DEFAULT_SQL_MD_PATH = '/abs/path/sql.md'
 const UI_OVERRIDES_KEY = 'sql2bi_ui_overrides_v1'
 const LAYOUT_MODE_KEY = 'sql2bi_layout_mode_v1'
 const ECHARTS_THEME_NAME = 'sql2bi_dynamic_theme_v1'
-
-const HEX_COLOR_RE = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/
-
-type UiPreset = 'dashboard' | 'sunset' | 'mint' | 'graphite' | 'midnight'
-type LayoutMode = 'classic' | 'focus'
-
-type UiOverrides = {
-  preset: UiPreset
-  theme: Partial<ThemeSpec>
-  chart_palette: string[]
-  shadow_level: number | null
-}
-
-type ThemePresetDef = {
-  label: string
-  ui: UiSpec
-}
-
-type ResolvedTheme = {
-  name: string
-  font_family: string
-  app_bg: string
-  canvas_bg: string
-  panel_bg: string
-  line_soft: string
-  line_strong: string
-  text_main: string
-  text_sub: string
-  text_mute: string
-  brand: string
-  brand_weak: string
-  radius_sm: number
-  radius_md: number
-  card_shadow: string
-}
 
 type WidgetVisual = {
   palette: string[]
@@ -68,230 +52,10 @@ type WidgetCardProps = {
   payload?: QueryDataPayload
   active: boolean
   themeName: string
+  focusMode: boolean
   visual: WidgetVisual
   onClick: () => void
   onCrossFilter: (value: string) => void
-}
-
-const DEFAULT_THEME: ResolvedTheme = {
-  name: 'studio_default',
-  font_family: '"Source Sans 3", "Noto Sans SC", sans-serif',
-  app_bg: '#f5f7fb',
-  canvas_bg: '#eef2ff',
-  panel_bg: '#ffffff',
-  line_soft: '#dce4f3',
-  line_strong: '#c7d4ec',
-  text_main: '#0f172a',
-  text_sub: '#334155',
-  text_mute: '#64748b',
-  brand: '#0ea5e9',
-  brand_weak: '#e0f2fe',
-  radius_sm: 8,
-  radius_md: 14,
-  card_shadow: '0 10px 28px rgba(15, 23, 42, 0.08)'
-}
-
-const DEFAULT_CHART_PALETTE = ['#0ea5e9', '#f59e0b', '#14b8a6', '#f43f5e', '#8b5cf6']
-
-const THEME_PRESETS: Record<Exclude<UiPreset, 'dashboard'>, ThemePresetDef> = {
-  sunset: {
-    label: 'Sunset Glow',
-    ui: {
-      theme: {
-        name: 'sunset_glow',
-        app_bg: '#fff7ed',
-        canvas_bg: '#ffedd5',
-        panel_bg: '#ffffff',
-        line_soft: '#fed7aa',
-        line_strong: '#fdba74',
-        text_main: '#7c2d12',
-        text_sub: '#9a3412',
-        text_mute: '#b45309',
-        brand: '#f97316',
-        brand_weak: '#ffedd5',
-        radius_sm: 10,
-        radius_md: 16,
-        card_shadow: '0 12px 28px rgba(154, 52, 18, 0.16)'
-      },
-      chart_palette: ['#f97316', '#fb7185', '#f59e0b', '#2dd4bf', '#a855f7']
-    }
-  },
-  mint: {
-    label: 'Mint Pulse',
-    ui: {
-      theme: {
-        name: 'mint_pulse',
-        app_bg: '#f0fdfa',
-        canvas_bg: '#d1fae5',
-        panel_bg: '#ffffff',
-        line_soft: '#a7f3d0',
-        line_strong: '#6ee7b7',
-        text_main: '#064e3b',
-        text_sub: '#065f46',
-        text_mute: '#047857',
-        brand: '#10b981',
-        brand_weak: '#d1fae5',
-        radius_sm: 9,
-        radius_md: 15,
-        card_shadow: '0 10px 24px rgba(4, 120, 87, 0.14)'
-      },
-      chart_palette: ['#10b981', '#0ea5e9', '#f59e0b', '#ef4444', '#6366f1']
-    }
-  },
-  graphite: {
-    label: 'Graphite Lab',
-    ui: {
-      theme: {
-        name: 'graphite_lab',
-        app_bg: '#f8fafc',
-        canvas_bg: '#e2e8f0',
-        panel_bg: '#ffffff',
-        line_soft: '#cbd5e1',
-        line_strong: '#94a3b8',
-        text_main: '#111827',
-        text_sub: '#1f2937',
-        text_mute: '#475569',
-        brand: '#2563eb',
-        brand_weak: '#dbeafe',
-        radius_sm: 7,
-        radius_md: 12,
-        card_shadow: '0 10px 24px rgba(15, 23, 42, 0.14)'
-      },
-      chart_palette: ['#2563eb', '#0891b2', '#f59e0b', '#db2777', '#16a34a']
-    }
-  },
-  midnight: {
-    label: 'Midnight Ops',
-    ui: {
-      theme: {
-        name: 'midnight_ops',
-        app_bg: '#0b1220',
-        canvas_bg: '#111827',
-        panel_bg: '#172033',
-        line_soft: '#25324a',
-        line_strong: '#334766',
-        text_main: '#e5edf8',
-        text_sub: '#b5c5df',
-        text_mute: '#8aa0c0',
-        brand: '#22d3ee',
-        brand_weak: '#0c4a6e',
-        radius_sm: 8,
-        radius_md: 14,
-        card_shadow: '0 14px 28px rgba(2, 6, 23, 0.42)'
-      },
-      chart_palette: ['#22d3ee', '#a78bfa', '#f59e0b', '#34d399', '#fb7185']
-    }
-  }
-}
-
-const DEFAULT_UI_OVERRIDES: UiOverrides = {
-  preset: 'dashboard',
-  theme: {},
-  chart_palette: [],
-  shadow_level: null
-}
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(max, Math.max(min, value))
-}
-
-function isUiPreset(value: string): value is UiPreset {
-  return value === 'dashboard' || value === 'sunset' || value === 'mint' || value === 'graphite' || value === 'midnight'
-}
-
-function isLayoutMode(value: string): value is LayoutMode {
-  return value === 'classic' || value === 'focus'
-}
-
-function normalizeHexColor(value: string | undefined, fallback: string): string {
-  if (!value) return fallback
-  const text = value.trim()
-  if (!HEX_COLOR_RE.test(text)) return fallback
-  if (text.length === 4) {
-    const r = text[1]
-    const g = text[2]
-    const b = text[3]
-    return `#${r}${r}${g}${g}${b}${b}`.toLowerCase()
-  }
-  return text.toLowerCase()
-}
-
-function hexToRgb(hex: string): { r: number; g: number; b: number } | null {
-  const normalized = normalizeHexColor(hex, '')
-  if (!normalized) return null
-  const m = /^#([0-9a-f]{6})$/i.exec(normalized)
-  if (!m) return null
-  const num = Number.parseInt(m[1], 16)
-  return {
-    r: (num >> 16) & 255,
-    g: (num >> 8) & 255,
-    b: num & 255
-  }
-}
-
-function withAlpha(hex: string, alpha: number, fallback: string): string {
-  const rgb = hexToRgb(hex)
-  if (!rgb) return fallback
-  return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${clamp(alpha, 0, 1)})`
-}
-
-function isColorDark(hex: string): boolean {
-  const rgb = hexToRgb(hex)
-  if (!rgb) return false
-  const brightness = (rgb.r * 299 + rgb.g * 587 + rgb.b * 114) / 1000
-  return brightness < 145
-}
-
-function formatKpiValue(value: number): string {
-  if (!Number.isFinite(value)) return '-'
-  if (Math.abs(value) >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`
-  if (Math.abs(value) >= 1_000) return `${(value / 1_000).toFixed(1)}K`
-  return String(Math.round(value * 100) / 100)
-}
-
-function normalizePalette(source: string[] | undefined, fallback: string[] = DEFAULT_CHART_PALETTE): string[] {
-  const pool = (source || []).map((c, idx) => normalizeHexColor(c, fallback[idx % fallback.length])).slice(0, 5)
-  while (pool.length < 5) {
-    pool.push(fallback[pool.length % fallback.length])
-  }
-  return pool
-}
-
-function mergeTheme(...parts: Array<Partial<ThemeSpec> | undefined>): ResolvedTheme {
-  const raw: Partial<ThemeSpec> = {}
-  parts.forEach((part) => {
-    if (!part) return
-    Object.assign(raw, part)
-  })
-
-  const brand = normalizeHexColor(raw.brand, DEFAULT_THEME.brand)
-  const brandWeakFallback = withAlpha(brand, 0.14, DEFAULT_THEME.brand_weak)
-
-  return {
-    name: String(raw.name || DEFAULT_THEME.name),
-    font_family: String(raw.font_family || DEFAULT_THEME.font_family),
-    app_bg: normalizeHexColor(raw.app_bg, DEFAULT_THEME.app_bg),
-    canvas_bg: normalizeHexColor(raw.canvas_bg, DEFAULT_THEME.canvas_bg),
-    panel_bg: normalizeHexColor(raw.panel_bg, DEFAULT_THEME.panel_bg),
-    line_soft: normalizeHexColor(raw.line_soft, DEFAULT_THEME.line_soft),
-    line_strong: normalizeHexColor(raw.line_strong, DEFAULT_THEME.line_strong),
-    text_main: normalizeHexColor(raw.text_main, DEFAULT_THEME.text_main),
-    text_sub: normalizeHexColor(raw.text_sub, DEFAULT_THEME.text_sub),
-    text_mute: normalizeHexColor(raw.text_mute, DEFAULT_THEME.text_mute),
-    brand,
-    brand_weak: normalizeHexColor(raw.brand_weak, brandWeakFallback),
-    radius_sm: clamp(Number(raw.radius_sm ?? DEFAULT_THEME.radius_sm), 4, 24),
-    radius_md: clamp(Number(raw.radius_md ?? DEFAULT_THEME.radius_md), 8, 28),
-    card_shadow: String(raw.card_shadow || DEFAULT_THEME.card_shadow)
-  }
-}
-
-function buildCardShadow(level: number): string {
-  if (level <= 0) return 'none'
-  const y = Math.max(2, Math.round(level * 0.45))
-  const blur = Math.max(8, Math.round(level * 2.6))
-  const alpha = Math.min(0.22, 0.04 + level * 0.007)
-  return `0 ${y}px ${blur}px rgba(15, 23, 42, ${alpha.toFixed(3)})`
 }
 
 function loadUiOverrides(): UiOverrides {
@@ -322,62 +86,6 @@ function loadUiOverrides(): UiOverrides {
 function loadLayoutMode(): LayoutMode {
   const raw = localStorage.getItem(LAYOUT_MODE_KEY)
   return raw && isLayoutMode(raw) ? raw : 'classic'
-}
-
-function buildEchartsTheme(theme: ResolvedTheme, palette: string[]): Record<string, unknown> {
-  return {
-    color: palette,
-    backgroundColor: 'transparent',
-    textStyle: {
-      color: theme.text_sub,
-      fontFamily: theme.font_family
-    },
-    legend: {
-      textStyle: {
-        color: theme.text_sub
-      }
-    },
-    categoryAxis: {
-      axisLine: {
-        lineStyle: {
-          color: theme.line_strong
-        }
-      },
-      axisLabel: {
-        color: theme.text_sub
-      },
-      splitLine: {
-        lineStyle: {
-          color: theme.line_soft
-        }
-      }
-    },
-    valueAxis: {
-      axisLine: {
-        lineStyle: {
-          color: theme.line_strong
-        }
-      },
-      axisLabel: {
-        color: theme.text_sub
-      },
-      splitLine: {
-        lineStyle: {
-          color: theme.line_soft
-        }
-      }
-    },
-    line: {
-      lineStyle: { width: 2.2 },
-      symbol: 'circle',
-      symbolSize: 6
-    },
-    bar: {
-      itemStyle: {
-        borderRadius: [6, 6, 0, 0]
-      }
-    }
-  }
 }
 
 function optionForPayload(payload: QueryDataPayload, visual: WidgetVisual): echarts.EChartsOption | null {
@@ -461,7 +169,7 @@ function optionForPayload(payload: QueryDataPayload, visual: WidgetVisual): echa
   return null
 }
 
-function WidgetCard({ widget, payload, active, themeName, visual, onClick, onCrossFilter }: WidgetCardProps) {
+function WidgetCard({ widget, payload, active, themeName, focusMode, visual, onClick, onCrossFilter }: WidgetCardProps) {
   const chartRef = useRef<HTMLDivElement | null>(null)
   const echartsRef = useRef<echarts.ECharts | null>(null)
   const chartThemeNameRef = useRef<string>('')
@@ -524,7 +232,7 @@ function WidgetCard({ widget, payload, active, themeName, visual, onClick, onCro
     <article
       className={`widget ${active ? 'active' : ''}`}
       style={{
-        gridColumn: `${(widget.position?.x || 0) + 1} / span ${widget.position?.w || 6}`,
+        gridColumn: focusMode ? '1 / span 12' : `${(widget.position?.x || 0) + 1} / span ${widget.position?.w || 6}`,
         gridRow: `${(widget.position?.y || 0) + 1} / span ${widget.position?.h || 4}`
       }}
       onClick={onClick}
@@ -584,6 +292,21 @@ function normalizeFilter(def: FilterDef, raw: string): FilterValue {
   return text
 }
 
+function toFriendlyError(error: unknown, backendUrl: string): string {
+  const raw = error instanceof Error ? error.message : String(error)
+  const text = raw.trim()
+
+  if (
+    text.startsWith('BACKEND_UNREACHABLE') ||
+    text.includes('Failed to fetch') ||
+    text.includes('Load failed')
+  ) {
+    return `Backend unavailable at ${backendUrl}. Start backend: bash services/start_backend.sh`
+  }
+
+  return text
+}
+
 function App() {
   const [backendUrl, setBackendUrl] = useState<string>(
     localStorage.getItem('sql2bi_backend') || DEFAULT_BACKEND_URL
@@ -599,6 +322,10 @@ function App() {
   const [error, setError] = useState<string>('')
   const [uiOverrides, setUiOverrides] = useState<UiOverrides>(() => loadUiOverrides())
   const [layoutMode, setLayoutMode] = useState<LayoutMode>(() => loadLayoutMode())
+
+  const uiOverridePersistTimerRef = useRef<number | null>(null)
+  const skipNextUiOverridePersistRef = useRef(false)
+  const lastEchartsThemeSignatureRef = useRef<string>('')
 
   const api = useMemo(() => new Sql2BiApi(backendUrl), [backendUrl])
 
@@ -663,6 +390,7 @@ function App() {
   const darkTheme = useMemo(() => isColorDark(activeTheme.app_bg), [activeTheme.app_bg])
 
   const kpiCards = useMemo(() => {
+    // TODO: support per-widget KPI ranking/format rules (asc|desc|abs + formatter) from dashboard/widget spec.
     return widgets
       .map((widget) => {
         const payload = widgetData[widget.query_id]
@@ -689,8 +417,30 @@ function App() {
     return widgets.filter((w) => w.query_id === selectedQueryId)
   }, [layoutMode, selectedQueryId, widgets])
 
+  const backendUnavailable = error.startsWith('Backend unavailable at ')
+
+
   useEffect(() => {
-    localStorage.setItem(UI_OVERRIDES_KEY, JSON.stringify(uiOverrides))
+    if (skipNextUiOverridePersistRef.current) {
+      skipNextUiOverridePersistRef.current = false
+      return
+    }
+
+    if (uiOverridePersistTimerRef.current !== null) {
+      window.clearTimeout(uiOverridePersistTimerRef.current)
+    }
+
+    uiOverridePersistTimerRef.current = window.setTimeout(() => {
+      localStorage.setItem(UI_OVERRIDES_KEY, JSON.stringify(uiOverrides))
+      uiOverridePersistTimerRef.current = null
+    }, 220)
+
+    return () => {
+      if (uiOverridePersistTimerRef.current !== null) {
+        window.clearTimeout(uiOverridePersistTimerRef.current)
+        uiOverridePersistTimerRef.current = null
+      }
+    }
   }, [uiOverrides])
 
   useEffect(() => {
@@ -718,7 +468,12 @@ function App() {
   }, [activeTheme])
 
   useEffect(() => {
+    const signature = JSON.stringify(echartsTheme)
+    if (signature === lastEchartsThemeSignatureRef.current) return
+
+    // ECharts does not expose theme unregister. We only register when payload actually changes.
     echarts.registerTheme(ECHARTS_THEME_NAME, echartsTheme)
+    lastEchartsThemeSignatureRef.current = signature
   }, [echartsTheme])
 
   const loadDashboard = useCallback(async () => {
@@ -732,11 +487,11 @@ function App() {
         setSelectedQueryId(db.pages[0].widgets[0].query_id)
       }
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e))
+      setError(toFriendlyError(e, backendUrl))
     } finally {
       setLoading(false)
     }
-  }, [api, selectedQueryId])
+  }, [api, backendUrl, selectedQueryId])
 
   const refreshWidgetData = useCallback(async () => {
     if (!currentPage) return
@@ -768,9 +523,9 @@ function App() {
       })
       setWidgetData(map)
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e))
+      setError(toFriendlyError(e, backendUrl))
     }
-  }, [api, currentPage, globalFilterValues, worksheetFilterValues])
+  }, [api, backendUrl, currentPage, globalFilterValues, worksheetFilterValues])
 
   useEffect(() => {
     loadDashboard().catch(() => {
@@ -792,11 +547,11 @@ function App() {
       await api.importSqlMd(sqlPath)
       await loadDashboard()
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e))
+      setError(toFriendlyError(e, backendUrl))
     } finally {
       setLoading(false)
     }
-  }, [api, loadDashboard, sqlPath])
+  }, [api, backendUrl, loadDashboard, sqlPath])
 
   const updateThemePatch = useCallback((patch: Partial<ThemeSpec>) => {
     setUiOverrides((prev) => ({
@@ -810,7 +565,10 @@ function App() {
 
   const onPresetChange = useCallback((nextPresetText: string) => {
     const preset: UiPreset = isUiPreset(nextPresetText) ? nextPresetText : 'dashboard'
-    const presetPalette = preset === 'dashboard' ? [] : normalizePalette(THEME_PRESETS[preset].ui.chart_palette)
+    const presetPalette =
+      preset === 'dashboard'
+        ? []
+        : normalizePalette(THEME_PRESETS[preset as Exclude<UiPreset, 'dashboard'>].ui.chart_palette)
     setUiOverrides({
       preset,
       theme: {},
@@ -832,6 +590,11 @@ function App() {
   }, [activePalette])
 
   const resetLocalTheme = useCallback(() => {
+    if (uiOverridePersistTimerRef.current !== null) {
+      window.clearTimeout(uiOverridePersistTimerRef.current)
+      uiOverridePersistTimerRef.current = null
+    }
+    skipNextUiOverridePersistRef.current = true
     setUiOverrides(DEFAULT_UI_OVERRIDES)
     localStorage.removeItem(UI_OVERRIDES_KEY)
   }, [])
@@ -892,6 +655,14 @@ function App() {
             </div>
           </div>
 
+          {backendUnavailable ? (
+            <div className="status-banner warning">
+              <div>Backend is not reachable. Start backend service first:</div>
+              <code>bash services/start_backend.sh</code>
+              <div className="hint">Then click Reload, or import demo sql.md.</div>
+            </div>
+          ) : null}
+
           {kpiCards.length > 0 ? (
             <section className="kpi-strip">
               {kpiCards.map((item) => (
@@ -919,6 +690,7 @@ function App() {
                 payload={widgetData[w.query_id]}
                 active={selectedQueryId === w.query_id}
                 themeName={ECHARTS_THEME_NAME}
+                focusMode={layoutMode === 'focus'}
                 visual={widgetVisual}
                 onClick={() => setSelectedQueryId(w.query_id)}
                 onCrossFilter={(value) => {

--- a/services/frontend/src/api.ts
+++ b/services/frontend/src/api.ts
@@ -12,13 +12,20 @@ export class Sql2BiApi {
   }
 
   private async request<T>(path: string, init?: RequestInit): Promise<T> {
-    const res = await fetch(`${this.baseUrl}${path}`, {
-      headers: {
-        'Content-Type': 'application/json',
-        ...(init?.headers || {})
-      },
-      ...init
-    })
+    let res: Response
+
+    try {
+      res = await fetch(`${this.baseUrl}${path}`, {
+        headers: {
+          'Content-Type': 'application/json',
+          ...(init?.headers || {})
+        },
+        ...init
+      })
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error)
+      throw new Error(`BACKEND_UNREACHABLE ${this.baseUrl}: ${reason}`)
+    }
 
     if (!res.ok) {
       const text = await res.text()

--- a/services/frontend/src/styles.css
+++ b/services/frontend/src/styles.css
@@ -35,11 +35,13 @@ body {
 }
 
 .app-root.theme-dark .top-toolbar {
+  background: var(--bg-panel);
   background: color-mix(in srgb, var(--bg-panel) 92%, black 8%);
 }
 
 .app-root.theme-dark .left-pane,
 .app-root.theme-dark .right-pane {
+  background: var(--bg-panel);
   background: color-mix(in srgb, var(--bg-panel) 94%, black 6%);
 }
 
@@ -53,12 +55,14 @@ body {
   z-index: 5;
   height: 56px;
   border-bottom: 1px solid var(--line-soft);
+  background: var(--bg-panel);
   background: color-mix(in srgb, var(--bg-panel) 88%, white 12%);
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: 0 12px;
   gap: 10px;
+  -webkit-backdrop-filter: blur(8px);
   backdrop-filter: blur(8px);
 }
 
@@ -137,6 +141,7 @@ button:disabled {
 
 .left-pane,
 .right-pane {
+  background: var(--bg-panel);
   background: color-mix(in srgb, var(--bg-panel) 93%, white 7%);
   padding: 12px;
   overflow: auto;
@@ -153,6 +158,7 @@ button:disabled {
 .center-pane {
   padding: 12px;
   overflow: auto;
+  background: var(--bg-app);
   background: radial-gradient(760px 280px at 10% 0%, var(--brand-glow), transparent 72%),
     linear-gradient(180deg, color-mix(in srgb, var(--bg-canvas) 70%, white 30%), var(--bg-app));
 }
@@ -207,6 +213,31 @@ button:disabled {
   color: var(--text-mute);
 }
 
+.status-banner {
+  margin-bottom: 10px;
+  border: 1px solid var(--line-soft);
+  border-radius: var(--radius-sm);
+  background: var(--bg-panel);
+  padding: 10px 12px;
+  display: grid;
+  gap: 6px;
+  font-size: 12px;
+}
+
+.status-banner.warning {
+  border-color: #f59e0b;
+  background: color-mix(in srgb, var(--bg-panel) 86%, #fef3c7 14%);
+}
+
+.status-banner code {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  border: 1px dashed var(--line-strong);
+  background: color-mix(in srgb, var(--bg-panel) 88%, white 12%);
+}
+
 .kpi-strip {
   margin-bottom: 10px;
   display: grid;
@@ -218,6 +249,7 @@ button:disabled {
   text-align: left;
   border: 1px solid var(--line-soft);
   border-radius: var(--radius-sm);
+  background: var(--bg-panel);
   background: linear-gradient(140deg, color-mix(in srgb, var(--bg-panel) 94%, white 6%), color-mix(in srgb, var(--brand-weak) 20%, var(--bg-panel) 80%));
   padding: 8px 10px;
   display: grid;
@@ -259,7 +291,6 @@ button:disabled {
 }
 
 .grid-canvas.focus-mode .widget {
-  grid-column: 1 / span 12 !important;
   min-height: 420px;
 }
 
@@ -306,6 +337,7 @@ button:disabled {
   border: 1px solid var(--line-soft);
   border-radius: var(--radius-sm);
   overflow: hidden;
+  background: var(--bg-panel);
   background: color-mix(in srgb, var(--bg-panel) 86%, var(--brand-weak) 14%);
 }
 

--- a/services/frontend/src/styles.css
+++ b/services/frontend/src/styles.css
@@ -1,15 +1,20 @@
 :root {
-  --bg-app: #f5f6f8;
+  --bg-app: #f5f7fb;
+  --bg-canvas: #eef2ff;
   --bg-panel: #ffffff;
-  --line-soft: #e6e8ec;
-  --line-strong: #d0d5dd;
-  --text-main: #101828;
-  --text-sub: #475467;
-  --text-mute: #667085;
-  --brand: #2f6fed;
-  --brand-weak: #e8f0ff;
-  --radius-sm: 6px;
-  --radius-md: 10px;
+  --line-soft: #dce4f3;
+  --line-strong: #c7d4ec;
+  --text-main: #0f172a;
+  --text-sub: #334155;
+  --text-mute: #64748b;
+  --brand: #0ea5e9;
+  --brand-weak: #e0f2fe;
+  --brand-ring: rgba(14, 165, 233, 0.2);
+  --brand-glow: rgba(14, 165, 233, 0.12);
+  --radius-sm: 8px;
+  --radius-md: 14px;
+  --card-shadow: 0 10px 28px rgba(15, 23, 42, 0.08);
+  --font-family-main: "Source Sans 3", "Noto Sans SC", sans-serif;
 }
 
 * {
@@ -18,24 +23,43 @@
 
 body {
   margin: 0;
-  background: var(--bg-app);
   color: var(--text-main);
-  font-family: "Source Sans 3", "Noto Sans SC", sans-serif;
+  font-family: var(--font-family-main);
+  background: radial-gradient(1000px 520px at -10% -25%, var(--brand-glow), transparent 70%),
+    radial-gradient(760px 460px at 120% -20%, var(--brand-weak), transparent 72%),
+    var(--bg-app);
 }
 
 .app-root {
   min-height: 100vh;
 }
 
+.app-root.theme-dark .top-toolbar {
+  background: color-mix(in srgb, var(--bg-panel) 92%, black 8%);
+}
+
+.app-root.theme-dark .left-pane,
+.app-root.theme-dark .right-pane {
+  background: color-mix(in srgb, var(--bg-panel) 94%, black 6%);
+}
+
+.app-root.layout-focus .left-pane {
+  opacity: 0.95;
+}
+
 .top-toolbar {
-  height: 52px;
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  height: 56px;
   border-bottom: 1px solid var(--line-soft);
-  background: var(--bg-panel);
+  background: color-mix(in srgb, var(--bg-panel) 88%, white 12%);
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: 0 12px;
-  gap: 8px;
+  gap: 10px;
+  backdrop-filter: blur(8px);
 }
 
 .toolbar-left,
@@ -48,6 +72,7 @@ body {
 .brand {
   font-size: 16px;
   font-weight: 700;
+  letter-spacing: 0.01em;
 }
 
 .backend-row,
@@ -63,52 +88,81 @@ body {
 }
 
 input,
+select,
 button {
   border: 1px solid var(--line-soft);
   border-radius: var(--radius-sm);
   font-size: 12px;
   padding: 6px 8px;
-  background: #fff;
+  background: var(--bg-panel);
+  color: var(--text-main);
+}
+
+input,
+select {
+  transition: border-color 0.18s ease, box-shadow 0.18s ease;
+}
+
+input:focus-visible,
+select:focus-visible {
+  outline: none;
+  border-color: var(--brand);
+  box-shadow: 0 0 0 2px var(--brand-ring);
+}
+
+select {
+  appearance: none;
 }
 
 button {
   cursor: pointer;
+  transition: border-color 0.18s ease, background-color 0.18s ease, transform 0.18s ease;
 }
 
-button:hover {
+button:hover:not(:disabled) {
   border-color: var(--brand);
+  transform: translateY(-1px);
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
 }
 
 .main-layout {
-  min-height: calc(100vh - 52px);
+  min-height: calc(100vh - 56px);
   display: grid;
-  grid-template-columns: 260px 1fr 320px;
+  grid-template-columns: 260px 1fr 340px;
 }
 
 .left-pane,
 .right-pane {
-  background: var(--bg-panel);
-  border-right: 1px solid var(--line-soft);
+  background: color-mix(in srgb, var(--bg-panel) 93%, white 7%);
   padding: 12px;
   overflow: auto;
 }
 
+.left-pane {
+  border-right: 1px solid var(--line-soft);
+}
+
 .right-pane {
-  border-right: none;
   border-left: 1px solid var(--line-soft);
 }
 
 .center-pane {
   padding: 12px;
   overflow: auto;
+  background: radial-gradient(760px 280px at 10% 0%, var(--brand-glow), transparent 72%),
+    linear-gradient(180deg, color-mix(in srgb, var(--bg-canvas) 70%, white 30%), var(--bg-app));
 }
 
 .pane-title {
   margin-bottom: 8px;
-  font-size: 13px;
+  font-size: 12px;
   color: var(--text-sub);
   text-transform: uppercase;
-  letter-spacing: 0.03em;
+  letter-spacing: 0.08em;
   font-weight: 700;
 }
 
@@ -120,7 +174,8 @@ button:hover {
 .filter-card {
   border: 1px solid var(--line-soft);
   border-radius: var(--radius-sm);
-  background: #fff;
+  background: var(--bg-panel);
+  box-shadow: var(--card-shadow);
   padding: 8px;
   margin-bottom: 8px;
   display: grid;
@@ -152,6 +207,50 @@ button:hover {
   color: var(--text-mute);
 }
 
+.kpi-strip {
+  margin-bottom: 10px;
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.kpi-card {
+  text-align: left;
+  border: 1px solid var(--line-soft);
+  border-radius: var(--radius-sm);
+  background: linear-gradient(140deg, color-mix(in srgb, var(--bg-panel) 94%, white 6%), color-mix(in srgb, var(--brand-weak) 20%, var(--bg-panel) 80%));
+  padding: 8px 10px;
+  display: grid;
+  gap: 3px;
+  box-shadow: var(--card-shadow);
+}
+
+.kpi-card.active {
+  border-color: var(--brand);
+  box-shadow: 0 0 0 2px var(--brand-ring), var(--card-shadow);
+}
+
+.kpi-label {
+  font-size: 11px;
+  color: var(--text-sub);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.kpi-value {
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--text-main);
+}
+
+.kpi-metric {
+  font-size: 10px;
+  color: var(--text-mute);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
 .grid-canvas {
   display: grid;
   grid-template-columns: repeat(12, minmax(0, 1fr));
@@ -159,19 +258,30 @@ button:hover {
   gap: 10px;
 }
 
+.grid-canvas.focus-mode .widget {
+  grid-column: 1 / span 12 !important;
+  min-height: 420px;
+}
+
 .widget {
   background: var(--bg-panel);
   border: 1px solid var(--line-soft);
   border-radius: var(--radius-md);
+  box-shadow: var(--card-shadow);
   padding: 8px;
   display: grid;
   grid-template-rows: auto 1fr auto;
   gap: 8px;
+  transition: transform 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease;
+}
+
+.widget:hover {
+  transform: translateY(-1px);
 }
 
 .widget.active {
   border-color: var(--brand);
-  box-shadow: 0 0 0 2px rgba(47, 111, 237, 0.14);
+  box-shadow: 0 0 0 2px var(--brand-ring), var(--card-shadow);
 }
 
 .widget-head {
@@ -196,6 +306,7 @@ button:hover {
   border: 1px solid var(--line-soft);
   border-radius: var(--radius-sm);
   overflow: hidden;
+  background: color-mix(in srgb, var(--bg-panel) 86%, var(--brand-weak) 14%);
 }
 
 .chart-canvas {
@@ -230,7 +341,101 @@ button:hover {
   color: var(--text-mute);
 }
 
-@media (max-width: 1280px) {
+.theme-studio {
+  border: 1px solid var(--line-soft);
+  border-radius: var(--radius-md);
+  padding: 10px;
+  margin-bottom: 12px;
+  background: var(--bg-panel);
+  box-shadow: var(--card-shadow);
+}
+
+.theme-field {
+  display: grid;
+  gap: 5px;
+  margin-bottom: 8px;
+}
+
+.theme-field label {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--text-sub);
+  letter-spacing: 0.03em;
+}
+
+.theme-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.theme-field input[type='color'] {
+  width: 100%;
+  height: 36px;
+  padding: 4px;
+}
+
+.theme-slider {
+  display: grid;
+  gap: 4px;
+  margin-bottom: 8px;
+}
+
+.theme-slider label {
+  font-size: 11px;
+  color: var(--text-sub);
+  font-weight: 700;
+}
+
+.theme-slider input[type='range'] {
+  width: 100%;
+}
+
+.palette-strip {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 6px;
+}
+
+.palette-item {
+  display: grid;
+  gap: 4px;
+  align-items: center;
+}
+
+.palette-item span {
+  font-size: 10px;
+  color: var(--text-mute);
+  text-align: center;
+}
+
+.palette-item input[type='color'] {
+  width: 100%;
+  height: 32px;
+  padding: 2px;
+}
+
+.theme-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 10px;
+}
+
+.theme-actions button {
+  flex: 1;
+}
+
+@media (max-width: 1360px) {
+  .main-layout {
+    grid-template-columns: 220px 1fr 280px;
+  }
+
+  .kpi-strip {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 1180px) {
   .main-layout {
     grid-template-columns: 220px 1fr;
   }
@@ -241,8 +446,16 @@ button:hover {
 }
 
 @media (max-width: 960px) {
+  .top-toolbar {
+    height: auto;
+    align-items: flex-start;
+    flex-direction: column;
+    padding: 8px 10px;
+  }
+
   .main-layout {
     grid-template-columns: 1fr;
+    min-height: calc(100vh - 82px);
   }
 
   .left-pane {
@@ -252,5 +465,9 @@ button:hover {
 
   .sql-row {
     flex-wrap: wrap;
+  }
+
+  .kpi-strip {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }

--- a/services/frontend/src/theme/echartsTheme.ts
+++ b/services/frontend/src/theme/echartsTheme.ts
@@ -1,0 +1,57 @@
+import type { ResolvedTheme } from './themeUtils'
+
+export function buildEchartsTheme(theme: ResolvedTheme, palette: string[]): Record<string, unknown> {
+  return {
+    color: palette,
+    backgroundColor: 'transparent',
+    textStyle: {
+      color: theme.text_sub,
+      fontFamily: theme.font_family
+    },
+    legend: {
+      textStyle: {
+        color: theme.text_sub
+      }
+    },
+    categoryAxis: {
+      axisLine: {
+        lineStyle: {
+          color: theme.line_strong
+        }
+      },
+      axisLabel: {
+        color: theme.text_sub
+      },
+      splitLine: {
+        lineStyle: {
+          color: theme.line_soft
+        }
+      }
+    },
+    valueAxis: {
+      axisLine: {
+        lineStyle: {
+          color: theme.line_strong
+        }
+      },
+      axisLabel: {
+        color: theme.text_sub
+      },
+      splitLine: {
+        lineStyle: {
+          color: theme.line_soft
+        }
+      }
+    },
+    line: {
+      lineStyle: { width: 2.2 },
+      symbol: 'circle',
+      symbolSize: 6
+    },
+    bar: {
+      itemStyle: {
+        borderRadius: [6, 6, 0, 0]
+      }
+    }
+  }
+}

--- a/services/frontend/src/theme/themeUtils.ts
+++ b/services/frontend/src/theme/themeUtils.ts
@@ -1,0 +1,257 @@
+import type { ThemeSpec, UiSpec } from '../types'
+
+const HEX_COLOR_RE = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/
+
+export type UiPreset = 'dashboard' | 'sunset' | 'mint' | 'graphite' | 'midnight'
+export type LayoutMode = 'classic' | 'focus'
+
+export type UiOverrides = {
+  preset: UiPreset
+  theme: Partial<ThemeSpec>
+  chart_palette: string[]
+  shadow_level: number | null
+}
+
+type ThemePresetDef = {
+  label: string
+  ui: UiSpec
+}
+
+export type ResolvedTheme = {
+  name: string
+  font_family: string
+  app_bg: string
+  canvas_bg: string
+  panel_bg: string
+  line_soft: string
+  line_strong: string
+  text_main: string
+  text_sub: string
+  text_mute: string
+  brand: string
+  brand_weak: string
+  radius_sm: number
+  radius_md: number
+  card_shadow: string
+}
+
+export const DEFAULT_THEME: ResolvedTheme = {
+  name: 'studio_default',
+  font_family: '"Source Sans 3", "Noto Sans SC", sans-serif',
+  app_bg: '#f5f7fb',
+  canvas_bg: '#eef2ff',
+  panel_bg: '#ffffff',
+  line_soft: '#dce4f3',
+  line_strong: '#c7d4ec',
+  text_main: '#0f172a',
+  text_sub: '#334155',
+  text_mute: '#64748b',
+  brand: '#0ea5e9',
+  brand_weak: '#e0f2fe',
+  radius_sm: 8,
+  radius_md: 14,
+  card_shadow: '0 10px 28px rgba(15, 23, 42, 0.08)'
+}
+
+export const DEFAULT_CHART_PALETTE = ['#0ea5e9', '#f59e0b', '#14b8a6', '#f43f5e', '#8b5cf6']
+
+export const THEME_PRESETS: Record<Exclude<UiPreset, 'dashboard'>, ThemePresetDef> = {
+  sunset: {
+    label: 'Sunset Glow',
+    ui: {
+      theme: {
+        name: 'sunset_glow',
+        app_bg: '#fff7ed',
+        canvas_bg: '#ffedd5',
+        panel_bg: '#ffffff',
+        line_soft: '#fed7aa',
+        line_strong: '#fdba74',
+        text_main: '#7c2d12',
+        text_sub: '#9a3412',
+        text_mute: '#b45309',
+        brand: '#f97316',
+        brand_weak: '#ffedd5',
+        radius_sm: 10,
+        radius_md: 16,
+        card_shadow: '0 12px 28px rgba(154, 52, 18, 0.16)'
+      },
+      chart_palette: ['#f97316', '#fb7185', '#f59e0b', '#2dd4bf', '#a855f7']
+    }
+  },
+  mint: {
+    label: 'Mint Pulse',
+    ui: {
+      theme: {
+        name: 'mint_pulse',
+        app_bg: '#f0fdfa',
+        canvas_bg: '#d1fae5',
+        panel_bg: '#ffffff',
+        line_soft: '#a7f3d0',
+        line_strong: '#6ee7b7',
+        text_main: '#064e3b',
+        text_sub: '#065f46',
+        text_mute: '#047857',
+        brand: '#10b981',
+        brand_weak: '#d1fae5',
+        radius_sm: 9,
+        radius_md: 15,
+        card_shadow: '0 10px 24px rgba(4, 120, 87, 0.14)'
+      },
+      chart_palette: ['#10b981', '#0ea5e9', '#f59e0b', '#ef4444', '#6366f1']
+    }
+  },
+  graphite: {
+    label: 'Graphite Lab',
+    ui: {
+      theme: {
+        name: 'graphite_lab',
+        app_bg: '#f8fafc',
+        canvas_bg: '#e2e8f0',
+        panel_bg: '#ffffff',
+        line_soft: '#cbd5e1',
+        line_strong: '#94a3b8',
+        text_main: '#111827',
+        text_sub: '#1f2937',
+        text_mute: '#475569',
+        brand: '#2563eb',
+        brand_weak: '#dbeafe',
+        radius_sm: 7,
+        radius_md: 12,
+        card_shadow: '0 10px 24px rgba(15, 23, 42, 0.14)'
+      },
+      chart_palette: ['#2563eb', '#0891b2', '#f59e0b', '#db2777', '#16a34a']
+    }
+  },
+  midnight: {
+    label: 'Midnight Ops',
+    ui: {
+      theme: {
+        name: 'midnight_ops',
+        app_bg: '#0b1220',
+        canvas_bg: '#111827',
+        panel_bg: '#172033',
+        line_soft: '#25324a',
+        line_strong: '#334766',
+        text_main: '#e5edf8',
+        text_sub: '#b5c5df',
+        text_mute: '#8aa0c0',
+        brand: '#22d3ee',
+        brand_weak: '#0c4a6e',
+        radius_sm: 8,
+        radius_md: 14,
+        card_shadow: '0 14px 28px rgba(2, 6, 23, 0.42)'
+      },
+      chart_palette: ['#22d3ee', '#a78bfa', '#f59e0b', '#34d399', '#fb7185']
+    }
+  }
+}
+
+export const DEFAULT_UI_OVERRIDES: UiOverrides = {
+  preset: 'dashboard',
+  theme: {},
+  chart_palette: [],
+  shadow_level: null
+}
+
+export function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
+export function isUiPreset(value: string): value is UiPreset {
+  return value === 'dashboard' || value === 'sunset' || value === 'mint' || value === 'graphite' || value === 'midnight'
+}
+
+export function isLayoutMode(value: string): value is LayoutMode {
+  return value === 'classic' || value === 'focus'
+}
+
+export function normalizeHexColor(value: string | undefined, fallback: string): string {
+  if (!value) return fallback
+  const text = value.trim()
+  if (!HEX_COLOR_RE.test(text)) return fallback
+  if (text.length === 4) {
+    const r = text[1]
+    const g = text[2]
+    const b = text[3]
+    return `#${r}${r}${g}${g}${b}${b}`.toLowerCase()
+  }
+  return text.toLowerCase()
+}
+
+function hexToRgb(hex: string): { r: number; g: number; b: number } | null {
+  const normalized = normalizeHexColor(hex, '')
+  if (!normalized) return null
+  const m = /^#([0-9a-f]{6})$/i.exec(normalized)
+  if (!m) return null
+  const num = Number.parseInt(m[1], 16)
+  return {
+    r: (num >> 16) & 255,
+    g: (num >> 8) & 255,
+    b: num & 255
+  }
+}
+
+export function withAlpha(hex: string, alpha: number, fallback: string): string {
+  const rgb = hexToRgb(hex)
+  if (!rgb) return fallback
+  return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${clamp(alpha, 0, 1)})`
+}
+
+export function isColorDark(hex: string): boolean {
+  const rgb = hexToRgb(hex)
+  if (!rgb) return false
+  const brightness = (rgb.r * 299 + rgb.g * 587 + rgb.b * 114) / 1000
+  return brightness < 145
+}
+
+export function formatKpiValue(value: number): string {
+  if (!Number.isFinite(value)) return '-'
+  if (Math.abs(value) >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`
+  if (Math.abs(value) >= 1_000) return `${(value / 1_000).toFixed(1)}K`
+  return String(Math.round(value * 100) / 100)
+}
+
+export function normalizePalette(source: string[] | undefined, fallback: string[] = DEFAULT_CHART_PALETTE): string[] {
+  const pool = (source || []).map((c, idx) => normalizeHexColor(c, fallback[idx % fallback.length])).slice(0, 5)
+  while (pool.length < 5) {
+    pool.push(fallback[pool.length % fallback.length])
+  }
+  return pool
+}
+
+export function mergeTheme(...parts: Array<Partial<ThemeSpec> | undefined>): ResolvedTheme {
+  const raw: Partial<ThemeSpec> = {}
+  parts.forEach((part) => {
+    if (!part) return
+    Object.assign(raw, part)
+  })
+
+  const brand = normalizeHexColor(raw.brand, DEFAULT_THEME.brand)
+  const brandWeakFallback = withAlpha(brand, 0.14, DEFAULT_THEME.brand_weak)
+
+  return {
+    name: String(raw.name || DEFAULT_THEME.name),
+    font_family: String(raw.font_family || DEFAULT_THEME.font_family),
+    app_bg: normalizeHexColor(raw.app_bg, DEFAULT_THEME.app_bg),
+    canvas_bg: normalizeHexColor(raw.canvas_bg, DEFAULT_THEME.canvas_bg),
+    panel_bg: normalizeHexColor(raw.panel_bg, DEFAULT_THEME.panel_bg),
+    line_soft: normalizeHexColor(raw.line_soft, DEFAULT_THEME.line_soft),
+    line_strong: normalizeHexColor(raw.line_strong, DEFAULT_THEME.line_strong),
+    text_main: normalizeHexColor(raw.text_main, DEFAULT_THEME.text_main),
+    text_sub: normalizeHexColor(raw.text_sub, DEFAULT_THEME.text_sub),
+    text_mute: normalizeHexColor(raw.text_mute, DEFAULT_THEME.text_mute),
+    brand,
+    brand_weak: normalizeHexColor(raw.brand_weak, brandWeakFallback),
+    radius_sm: clamp(Number(raw.radius_sm ?? DEFAULT_THEME.radius_sm), 4, 24),
+    radius_md: clamp(Number(raw.radius_md ?? DEFAULT_THEME.radius_md), 8, 28),
+    card_shadow: String(raw.card_shadow || DEFAULT_THEME.card_shadow)
+  }
+}
+
+export function buildCardShadow(level: number): string {
+  if (level <= 0) return 'none'
+  const y = Math.max(2, Math.round(level * 0.45))
+  const blur = Math.max(8, Math.round(level * 2.6))
+  const alpha = Math.min(0.22, 0.04 + level * 0.007)
+  return `0 ${y}px ${blur}px rgba(15, 23, 42, ${alpha.toFixed(3)})`
+}

--- a/services/frontend/src/types.ts
+++ b/services/frontend/src/types.ts
@@ -31,9 +31,33 @@ export type DashboardPage = {
   widgets: WidgetSpec[]
 }
 
+export type ThemeSpec = {
+  name?: string
+  font_family?: string
+  app_bg?: string
+  canvas_bg?: string
+  panel_bg?: string
+  line_soft?: string
+  line_strong?: string
+  text_main?: string
+  text_sub?: string
+  text_mute?: string
+  brand?: string
+  brand_weak?: string
+  radius_sm?: number
+  radius_md?: number
+  card_shadow?: string
+}
+
+export type UiSpec = {
+  theme?: ThemeSpec
+  chart_palette?: string[]
+}
+
 export type DashboardSpec = {
   version: string
   name: string
+  ui?: UiSpec
   grid: { columns: number; rowHeight: number }
   pages: DashboardPage[]
 }

--- a/services/start_frontend.sh
+++ b/services/start_frontend.sh
@@ -4,6 +4,16 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FRONTEND_HOST="${FRONTEND_HOST:-127.0.0.1}"
 FRONTEND_PORT="${FRONTEND_PORT:-15173}"
+BACKEND_HOST="${BACKEND_HOST:-127.0.0.1}"
+BACKEND_PORT="${BACKEND_PORT:-18000}"
+BACKEND_HEALTH_URL="${BACKEND_HEALTH_URL:-http://${BACKEND_HOST}:${BACKEND_PORT}/api/health}"
+
+if command -v curl >/dev/null 2>&1; then
+  if ! curl -fsS --max-time 1 "$BACKEND_HEALTH_URL" >/dev/null; then
+    echo "[frontend] warning: backend not reachable at ${BACKEND_HEALTH_URL}" >&2
+    echo "[frontend] tip: in another terminal run: bash services/start_backend.sh" >&2
+  fi
+fi
 
 if [[ -d "$ROOT/frontend/node_modules" ]]; then
   cd "$ROOT/frontend"

--- a/skills/sql-to-bi-builder/SKILL.md
+++ b/skills/sql-to-bi-builder/SKILL.md
@@ -120,6 +120,13 @@ bash /abs/path/out/services/start_frontend.sh
 - `services/frontend`: Frontend service consuming backend API.
 - `services/start_backend.sh` and `services/start_frontend.sh`: service start scripts.
 
+### UI Upgrade Notes (2026-03)
+When using repo-level service UI (`services/frontend`), the upgraded experience includes:
+- KPI summary strip (click-to-focus widgets)
+- Layout switch (`Classic` / `Focus`)
+- New `Midnight Ops` theme preset
+- stronger visual hierarchy for demos
+
 ## Heuristic References
 Load only the file needed for the current issue:
 - SQL parsing and naming constraints: `references/sql_style.md`

--- a/skills/sql-to-bi-builder/scripts/build_dashboard_spec.py
+++ b/skills/sql-to-bi-builder/scripts/build_dashboard_spec.py
@@ -132,6 +132,26 @@ def main() -> None:
     dashboard = {
         "version": "0.1.0",
         "name": "SQL Generated Dashboard",
+        "ui": {
+            "theme": {
+                "name": "studio_sky",
+                "font_family": '"Source Sans 3", "Noto Sans SC", sans-serif',
+                "app_bg": "#f5f7fb",
+                "canvas_bg": "#eef2ff",
+                "panel_bg": "#ffffff",
+                "line_soft": "#dce4f3",
+                "line_strong": "#c7d4ec",
+                "text_main": "#0f172a",
+                "text_sub": "#334155",
+                "text_mute": "#64748b",
+                "brand": "#0ea5e9",
+                "brand_weak": "#e0f2fe",
+                "radius_sm": 8,
+                "radius_md": 14,
+                "card_shadow": "0 10px 28px rgba(15, 23, 42, 0.08)",
+            },
+            "chart_palette": ["#0ea5e9", "#f59e0b", "#14b8a6", "#f43f5e", "#8b5cf6"],
+        },
         "grid": {"columns": GRID_COLS, "rowHeight": 1},
         "pages": [
             {

--- a/skills/sql-to-bi-builder/scripts/build_dashboard_spec.py
+++ b/skills/sql-to-bi-builder/scripts/build_dashboard_spec.py
@@ -48,6 +48,19 @@ def main() -> None:
     parser.add_argument("--semantics", required=True, help="Path to semantic_catalog.json")
     parser.add_argument("--charts", required=True, help="Path to chart_plan.json")
     parser.add_argument("--output", required=True, help="Path to dashboard.json")
+    parser.add_argument(
+        "--with-ui-theme",
+        dest="with_ui_theme",
+        action="store_true",
+        help="Inject default ui.theme + chart_palette into dashboard.json (default)",
+    )
+    parser.add_argument(
+        "--without-ui-theme",
+        dest="with_ui_theme",
+        action="store_false",
+        help="Skip ui defaults; emit a semantic/structure-only dashboard.json",
+    )
+    parser.set_defaults(with_ui_theme=True)
     args = parser.parse_args()
 
     queries = json.loads(Path(args.queries).read_text(encoding="utf-8")).get("queries", [])
@@ -132,7 +145,19 @@ def main() -> None:
     dashboard = {
         "version": "0.1.0",
         "name": "SQL Generated Dashboard",
-        "ui": {
+        "grid": {"columns": GRID_COLS, "rowHeight": 1},
+        "pages": [
+            {
+                "id": "page_main",
+                "title": "Overview",
+                "global_filters": global_filters,
+                "widgets": widgets,
+            }
+        ],
+    }
+
+    if args.with_ui_theme:
+        dashboard["ui"] = {
             "theme": {
                 "name": "studio_sky",
                 "font_family": '"Source Sans 3", "Noto Sans SC", sans-serif',
@@ -151,23 +176,16 @@ def main() -> None:
                 "card_shadow": "0 10px 28px rgba(15, 23, 42, 0.08)",
             },
             "chart_palette": ["#0ea5e9", "#f59e0b", "#14b8a6", "#f43f5e", "#8b5cf6"],
-        },
-        "grid": {"columns": GRID_COLS, "rowHeight": 1},
-        "pages": [
-            {
-                "id": "page_main",
-                "title": "Overview",
-                "global_filters": global_filters,
-                "widgets": widgets,
-            }
-        ],
-    }
+        }
 
     out_path = Path(args.output)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(json.dumps(dashboard, ensure_ascii=False, indent=2), encoding="utf-8")
 
-    print(f"Built dashboard spec with {len(widgets)} widgets -> {out_path}")
+    print(
+        f"Built dashboard spec with {len(widgets)} widgets"
+        f" (with_ui_theme={args.with_ui_theme}) -> {out_path}"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_build_dashboard_spec.py
+++ b/tests/test_build_dashboard_spec.py
@@ -1,0 +1,153 @@
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / 'skills/sql-to-bi-builder/scripts/build_dashboard_spec.py'
+
+
+def load_module():
+  spec = importlib.util.spec_from_file_location('build_dashboard_spec', SCRIPT_PATH)
+  if spec is None or spec.loader is None:
+    raise RuntimeError(f'Failed to load module from {SCRIPT_PATH}')
+  module = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(module)
+  return module
+
+
+class BuildDashboardSpecHelpersTest(unittest.TestCase):
+  @classmethod
+  def setUpClass(cls):
+    cls.mod = load_module()
+
+  def test_unique_keep_order(self):
+    result = self.mod.unique_keep_order(['region', 'dt', 'region', '', 'dt', 'channel'])
+    self.assertEqual(result, ['region', 'dt', 'channel'])
+
+  def test_next_position_wraps_when_exceeding_grid(self):
+    x, y, next_x, next_y, row_h = self.mod.next_position(cursor_x=9, cursor_y=0, h_row_max=3, w=6, h=4)
+    self.assertEqual((x, y), (0, 3))
+    self.assertEqual((next_x, next_y, row_h), (6, 3, 4))
+
+
+class BuildDashboardSpecCliTest(unittest.TestCase):
+  def setUp(self):
+    self.tmp = tempfile.TemporaryDirectory(prefix='sql2bi-test-')
+    self.tmp_path = Path(self.tmp.name)
+
+    self.queries = self.tmp_path / 'query_catalog.json'
+    self.semantics = self.tmp_path / 'semantic_catalog.json'
+    self.charts = self.tmp_path / 'chart_plan.json'
+
+    self.queries.write_text(
+      json.dumps(
+        {
+          'queries': [
+            {
+              'id': 'q_sales',
+              'title': 'Sales',
+              'filters': ['region'],
+              'datasource': 'duckdb_demo',
+              'refresh': '5m',
+            },
+            {
+              'id': 'q_users',
+              'title': 'Users',
+              'filters': [],
+            },
+          ]
+        },
+        ensure_ascii=False,
+      ),
+      encoding='utf-8',
+    )
+
+    self.semantics.write_text(
+      json.dumps(
+        {
+          'queries': [
+            {
+              'id': 'q_sales',
+              'metrics': ['gmv'],
+              'dimensions': ['dt'],
+              'time_fields': ['dt'],
+              'dsl_filter_fields': ['dt'],
+              'dsl_filters': [
+                {
+                  'field': 'dt',
+                  'operator': 'between',
+                  'suggested_widget': 'date_range',
+                  'is_time': True,
+                }
+              ],
+            },
+            {
+              'id': 'q_users',
+              'metrics': ['uv'],
+              'dimensions': ['dt'],
+              'time_fields': ['dt'],
+              'dsl_filter_fields': [],
+              'dsl_filters': [],
+            },
+          ]
+        },
+        ensure_ascii=False,
+      ),
+      encoding='utf-8',
+    )
+
+    self.charts.write_text(
+      json.dumps({'charts': [{'id': 'q_sales', 'chart': 'line'}, {'id': 'q_users', 'chart': 'kpi'}]}, ensure_ascii=False),
+      encoding='utf-8',
+    )
+
+  def tearDown(self):
+    self.tmp.cleanup()
+
+  def run_builder(self, output: Path, extra_args=None):
+    cmd = [
+      sys.executable,
+      str(SCRIPT_PATH),
+      '--queries',
+      str(self.queries),
+      '--semantics',
+      str(self.semantics),
+      '--charts',
+      str(self.charts),
+      '--output',
+      str(output),
+    ]
+    if extra_args:
+      cmd.extend(extra_args)
+
+    completed = subprocess.run(cmd, cwd=REPO_ROOT, check=True, capture_output=True, text=True)
+    return completed
+
+  def test_default_includes_ui_theme(self):
+    output = self.tmp_path / 'dashboard.with-ui.json'
+    completed = self.run_builder(output)
+    self.assertIn('with_ui_theme=True', completed.stdout)
+
+    data = json.loads(output.read_text(encoding='utf-8'))
+    self.assertIn('ui', data)
+    self.assertIn('theme', data['ui'])
+    self.assertIn('chart_palette', data['ui'])
+    self.assertEqual(len(data['pages'][0]['widgets']), 2)
+
+  def test_without_ui_theme_omits_ui(self):
+    output = self.tmp_path / 'dashboard.no-ui.json'
+    completed = self.run_builder(output, ['--without-ui-theme'])
+    self.assertIn('with_ui_theme=False', completed.stdout)
+
+    data = json.loads(output.read_text(encoding='utf-8'))
+    self.assertNotIn('ui', data)
+    self.assertIn('grid', data)
+    self.assertEqual(data['pages'][0]['title'], 'Overview')
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
> 自动更新标记：2026-03-18 23:41:09 GMT+8

## 背景与目标
- 对应 Review：PR #10 代码审阅建议（可维护性、性能、兼容性与可测试性）
- 目标：在保持 UI 展示能力的前提下，降低 App.tsx 复杂度，改进本地持久化与错误提示体验，并补齐最小测试闭环。

## 主要改动
1. 前端可维护性与体验
   - 抽离主题逻辑：新增
     - `services/frontend/src/theme/themeUtils.ts`
     - `services/frontend/src/theme/echartsTheme.ts`
   - `App.tsx` 引用抽离模块，降低单文件复杂度
   - `uiOverrides` 持久化增加 debounce（220ms），减少 slider/颜色拖动时的高频 `localStorage` 写入
   - `resetLocalTheme()` 增加 skip 逻辑，避免 `removeItem` 后 effect 立即写回默认值
   - ECharts 主题注册增加签名判断，仅在主题内容变化时重新注册
   - Focus 模式去除 `!important`，改为渲染层控制布局
   - 后端未启动时提供友好提示（不再只显示 `Load failed`）

2. 样式兼容性增强
   - 对 `color-mix(...)` 场景增加 fallback 背景值
   - 增加 `-webkit-backdrop-filter` 兼容声明

3. Dashboard 生成脚本能力增强
   - `build_dashboard_spec.py` 新增开关：
     - `--with-ui-theme`（默认）
     - `--without-ui-theme`（仅结构/语义，不注入默认 UI）

4. 工程与质量保障
   - hooks 兼容性修复：
     - 无 `rg` 环境下使用 `grep` fallback
     - 增加 `PYTHONPYCACHEPREFIX`，规避 macOS/sandbox 下 pycache 权限报错
   - 新增最小单测套件：`tests/test_build_dashboard_spec.py`
     - helper 行为（`unique_keep_order`、`next_position`）
     - CLI 行为（默认 with UI / `--without-ui-theme`）
   - `pre-push` 接入该最小单测，形成 push 前质量闭环

## 与 Review 建议对照
- [x] App.tsx 先做主题相关模块抽离，降低膨胀趋势
- [x] localStorage 高频写入改为 debounce，并修复 reset 写回语义
- [x] ECharts 同名主题重复注册风险：增加内容签名判断
- [x] Focus 模式去掉 `!important`，保留单一布局控制机制
- [x] KPI 排序语义暂以 TODO 标注后续规范化方向
- [x] `build_dashboard_spec` 支持可配置注入 UI 默认主题
- [x] 文档示例路径改为 `<repo_root>/...` 通用形式

## 行为变化
- 之前：后端未启动时前端常见错误为 `Load failed`，定位成本高
- 现在：前端与启动脚本都会明确提示“backend not reachable”并给出启动命令

## 验证
- `python3 -m unittest discover -s tests -p 'test_*.py'` ✅
- `npm --prefix services/frontend run build` ✅
- `bash .githooks/pre-push` ✅（含 smoke pipeline + unit tests）

## 风险与兼容性
- 风险：新增 hooks 与错误提示逻辑，可能影响极少数本地自定义流程
- 兼容性：
  - `DashboardSpec.ui` 仍为可选字段，旧 dashboard 继续可用
  - `--with-ui-theme` 保持默认行为，不破坏现有流水线
